### PR TITLE
don't decode retrieved translations, as Locale::Simple already handles that

### DIFF
--- a/lib/DDG/Publisher/SiteRole.pm
+++ b/lib/DDG/Publisher/SiteRole.pm
@@ -145,7 +145,6 @@ sub _build_template_engine {
 	for my $key (keys %{ Locale::Simple->coderef_hash }) {
 		$xslate_locale_functions{$key} = sub {
 			my $translation = Locale::Simple->coderef_hash->{$key}->(@_);
-			utf8::decode($translation);
 			return mark_raw($translation);
 		};
 	}


### PR DESCRIPTION
This fixes for example the dropdown menu at
https://duckduckgo.com/about?t=i&kad=tr_TR
