### PR TITLE
Broken forum link

### DIFF
--- a/share/site/duckduckhack/doc.tx
+++ b/share/site/duckduckhack/doc.tx
@@ -58,7 +58,7 @@
 									</span>
 									<: } :>
 									<h5 class="callout-row__text  icon" style="font-weight: bold;overflow:hidden;margin: 0;line-height:30px;/* dirty workaround -temp */">
-									Not helpful?  Help <a href="<: $file_path :>/<: if $file_dir { $file_dir :>/<: } $file :>.md">Edit</a> or <a href="http://duckduckgo.com/forum">Ask the Community</a></h5>									
+									Not helpful?  Help <a href="<: $file_path :>/<: if $file_dir { $file_dir :>/<: } $file :>.md">Edit</a> or <a href="http://duck.co/forum">Ask the Community</a></h5>									
 								</div>
 							  </div>
 							</div>							


### PR DESCRIPTION
Changed to http://duck.co/forum (previously searching for "forum" on DDH)
