### PR TITLE
Removing link from DDG front page tag line.

### DIFF
--- a/share/site/duckduckgo/index.tx
+++ b/share/site/duckduckgo/index.tx
@@ -1,7 +1,9 @@
 <!-- <: $f.locale :> <: l('All Settings') :> -->
 		
 <div id="tagline_homepage">
-<: lp('frontpage','The search engine that %s.',r('<a href="http://donttrack.us/">') ~ lp('frontpage',"doesn't track you") ~ r('</a>')) :>.
+<: # Leaving this as two tokens as we may wish to wrap the second part in other
+   # functionality some day :>
+<: lp('frontpage','The search engine that %s.', lp('frontpage',"doesn't track you")) :>
 </div>
 		
 		<div id="error_homepage"></div>


### PR DESCRIPTION
Should be deployed alongside latest Locale package.
