### PR TITLE
Removing "Add to Browser" / "Use in %s" text for now

### DIFF
--- a/share/site/donttrackus/index.tx
+++ b/share/site/donttrackus/index.tx
@@ -161,9 +161,6 @@
 
 <div style="margin-top:10px;"></div>
 <h4><: l('Use %s instead.',r('<a href="https://duckduckgo.com/">DuckDuckGo</a>')) :>
-	<script type="text/JavaScript">
-	nib(0,'','&nbsp;','.');
-	</script>
 </h4>
 <div style="margin-top:10px;"></div>
 <h4><: lp('privacyis',"Privacy is just %s of %s reasons why it's awesome.",r('<a href="https://duckduckgo.com/about.html">') ~ lp('privacyis','one') ~ r('</a>'),r('<a href="https://duckduckgo.com/goodies/">') ~ lp('privacyis','many') ~ r('</a>')) :></h4>


### PR DESCRIPTION
This fixes the 'Use in %s' issue which was reported - this text used to be:

![Old add to](http://jbrt.org/ddg/add-to.png)

It needs to be updated to support new the new js, but should perhaps be removed for now as it's pretty fugly.

If someone knows how to do it properly + quickly, please jump in.
