### PR TITLE
Changing "What's New" link to spread link, with existing translated token

### DIFF
--- a/share/site/duckduckgo/index.tx
+++ b/share/site/duckduckgo/index.tx
@@ -3,7 +3,7 @@
 <div id="tagline_homepage" class="tag-home">
 
 	<: lp('frontpage','The search engine that %s.', lp('frontpage',"doesn't track you")) :>
-	<a href="/whatsnew" class="r-block--screen-xs"><: l("What's new!") :></a>
+	<a href="/spread" class="r-block--screen-xs"><: l("Help Spread DuckDuckGo!") :></a>
 
 <!--
 	<a href="http://donttrack.us/" class="tag-home__link"><: lp('frontpage','Search %s.',r('<em>') ~ lp('frontpage','Anonymously') ~ r('</em>')) :></a>


### PR DESCRIPTION
Token has been in place for some time, so has decent coverage. Can change to "Help spread..." text when it has been up for a few days or so.
