### PR TITLE
Removed redundant OpenSearch link

### DIFF
--- a/share/site/duckduckgo/meta/base.tx
+++ b/share/site/duckduckgo/meta/base.tx
@@ -10,8 +10,6 @@
 <script type="text/javascript" src="/locales/<: $f.locale :>/LC_MESSAGES/<: $s.locale_domain :>+sprintf+gettext+locale-simple.<: $locale_package_version :>.js"></script>
 <script type="text/javascript" src="<: $ENV.DDG_DYNAMIC_JS_FILE || '/duckduck.js' :>"></script>
 
-<link title="DuckDuckGo" type="application/opensearchdescription+xml" rel="search" href="/opensearch.xml">
-
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="16x16 24x24 32x32 64x64"/>
 <link rel="apple-touch-icon" href="/assets/icons/meta/DDG-iOS-icon_60x60.png"/>
 <link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/meta/DDG-iOS-icon_76x76.png"/>


### PR DESCRIPTION
For some reason, there were two of them.

From having a quick look at blame I see there alread was some [discussion](https://github.com/duckduckgo/duckduckgo-publisher/commit/79e3a364ab3a4e6a34911ea8a4c875cbb4609864#comments) about this but I do not understand what was the actual outcome, thus this pull request.
