### PR TITLE
Homepage focus

### DIFF
--- a/share/site/duckduckgo/footer_homepage.tx
+++ b/share/site/duckduckgo/footer_homepage.tx
@@ -8,7 +8,6 @@
 	}
 	var err=new RegExp('[\?\&]e=([^\&]+)');var errm=new Array();errm['2']='<: js(l('no search')) :>';errm['3']='<: l('search too long') :>';errm['4']='<: js(l('not %s encoding','UTF-8')) :>';if (err.test(window.location.href)) seterr('Oops, '+(errm[RegExp.$1]?errm[RegExp.$1]:'<: js(l('there was an error.')) :>')+' &nbsp;<: js(l('Please try again')) :>');};if (ip) setTimeout('nuo(1)',250);nip(1)
 	
-	setTimeout('document.x.q.focus()',50);
 	if (kurl) {
 	  document.getElementById("logo_homepage_link").href += (document.getElementById("logo_homepage_link").href.indexOf('?')==-1 ? '?t=i' : '') + kurl;
 	}


### PR DESCRIPTION
Anyone know what edge case/bug this was added for? It causes a lot of issues on mobile. And changing focus some arbitrary amount of time after the page loads is never going to end well. On slower machines a user might start typing or interacting with the page and it will jump the focus, interrupting them.

Everything seems to work fine in desktop browsers without it.

@sdougbrown @nilnilnil @yegg 
