### PR TITLE
Revert "Revert "Remove minimal-ui viewport meta tag""

### DIFF
--- a/share/site/duckduckgo/meta/base.tx
+++ b/share/site/duckduckgo/meta/base.tx
@@ -1,6 +1,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 <meta http-equiv="content-type" content="text/html; charset=UTF-8;charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimal-ui" />
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1" />
 <meta name="HandheldFriendly" content="true"/>
 
 <link rel="canonical" href="https://duckduckgo.com<: $url :>">


### PR DESCRIPTION
Not supported for DuckDuckGo on iOS 8 so remove everywhere.
