### PR TITLE
whatisdnt: Put link in correct order among text.

### DIFF
--- a/share/site/whatisdnt/index.tx
+++ b/share/site/whatisdnt/index.tx
@@ -150,7 +150,7 @@
 </div>
 
 <h4>
-	<: lp('socheckout','So %s check out %s,%s and support other services that really Do Not Track.', r('<a href="https://duckduckgo.com/goodies/">') ~ lp('socheckout','our goodies') ~ r('</a>'), r('<br/>')) :>
+	<: lp('socheckout','So check out %s,%s and support other services that really Do Not Track.', r('<a href="https://duckduckgo.com/goodies/">') ~ lp('socheckout','our goodies') ~ r('</a>'), r('<br/>')) :>
 </h4>
 <div class="frame-wrap" id="fig16" name="fig16">
 	<div class="frame"><span class="fig"><: l('Fig. %d', 16) :></span>


### PR DESCRIPTION
Quick fix for something I noticed.

Before:

![2014-09-05-15 36 33_1440x900](https://cloud.githubusercontent.com/assets/7873686/4171922/a87e8780-3542-11e4-83de-36097fe90534.png)

After:

![2014-09-05-17 18 37_1440x900](https://cloud.githubusercontent.com/assets/7873686/4171923/ae546e22-3542-11e4-99d0-bc660f24fe2f.png)
