### PR TITLE
dist.ini: bump Markdent to minimum 0.24.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -61,7 +61,7 @@ String::ProgressBar = 0.03
 JSON = 2.57
 ; DuckDuckHack docs.
 IPC::Run = 0
-Markdent = 0
+Markdent = 0.24
 File::Path = 0
 File::Find = 0
 Text::Trim = 0


### PR DESCRIPTION
This resolves an interaction issue between newer versions of
TypeConstraints and older versions of Markdent.

cc: @moollaza  This addresses the confusion from #118.
