### PR TITLE
Add syntax highlighting to docs via highlightjs

### DIFF
--- a/share/site/duckduckhack/doc.tx
+++ b/share/site/duckduckhack/doc.tx
@@ -4,6 +4,7 @@
 	<title><: $title :><: if $category { :> / <: $category } :> / DuckDuckHack</title>
 	<link rel="stylesheet" type="text/css" href="/static/js/tomorrow-night-eighties.css">
 	<script type="text/javascript" src="/static/js/highlight.pack.js"></script>
+	<script>hljs.initHighlightingOnLoad();</script>
 </head>
 <body class="pg-duckduckhack  texture">
 	<div id="wrapper" class="site-wrapper">		


### PR DESCRIPTION
I've purposely modified "doc.tx" in Publisher so these files aren't needlessly loaded and executed on the rest of the Comm-Plat. Let me know if you agree with this approach.

I've tested this in duckpan publisher and it works as expected, adding these lines to the `<head>` only for the docs pages.

**Update:** I just realized the section I modified will only affect the preview in DuckPAN because it's wrapped in `<: if !$raw_output { :>` -- I'm not sure how else to make this apply only to the docs pages, other then putting in the `<body>` which is kinda ugly.

Any suggestions?

---

An associated PR to the Community-Platform has been made which adds the required assets: https://github.com/duckduckgo/community-platform/pull/330

//cc @sdougbrown @russellholt @jbarrett 
