### PR TITLE
Switch deprecated TestsEOL to Test::EOL

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,7 +34,7 @@ version_regexp = ^(.+)$
 [PodSyntaxTests]
 [GithubMeta]
 [Repository]
-[EOLTests]
+[Test::EOL]
 trailing_whitespace = 0
 
 [@Git]


### PR DESCRIPTION
We were using `EOLTests` (https://metacpan.org/pod/Dist::Zilla::Plugin::EOLTests) which is now deprecated. Switching to `Test::EOL` should solve the problem

//cc @nilnilnil 
