### PR TITLE
remove [Repository], fix [PromptIfStale] option

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_holder = DuckDuckGo, Inc. L<http://duckduckgo.com/>
 copyright_year   = 2012
 
 [PromptIfStale]
-index = http://duckpan.org
+index_base_url = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [GatherDir]
@@ -33,7 +33,6 @@ version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
 [GithubMeta]
-[Repository]
 [Test::EOL]
 trailing_whitespace = 0
 


### PR DESCRIPTION
`[Repository]` is clashing with another Dzil Plugin, (I think `[GitHubMeta]`), trying to set the `web` property of the generated META.yml

`index_base_url` should be updated to match newest PromptIfStale requirements

//cc @nilnilnil @sdougbrown @jbarrett 