### PR TITLE
Don't wait for DOMReady to instantiate the page instance anymore

### DIFF
--- a/share/site/duckduckgo/head_js.tx
+++ b/share/site/duckduckgo/head_js.tx
@@ -6,8 +6,6 @@
 <: } :>
 <: if !$js_skip_init { :>
 <script type="text/javascript">
-	DDG.ready(function(){
-		DDG.page = new DDG.Pages.<: if $js_page_type { $js_page_type } else if $homepage { :>Home<: } else { :>Static<: } :>();
-	});
+    DDG.page = new DDG.Pages.<: if $js_page_type { $js_page_type } else if $homepage { :>Home<: } else { :>Static<: } :>();
 </script>
 <: } :>

--- a/share/site/duckduckgo/settings.tx
+++ b/share/site/duckduckgo/settings.tx
@@ -8,12 +8,8 @@
 </div>
 
 <script>
-    DDG.require('settings',function(){
-        DDG.ready(function(){
-            DDG.page = new DDG.Pages.Settings({
-                appendTo: '.settings-page-wrapper'
-            });
-        });
+    DDG.page = new DDG.Pages.Settings({
+        appendTo: '.settings-page-wrapper'
     });
 </script>
 


### PR DESCRIPTION
Making publisher page instantiation consistent so it happens at page load instead of waiting for DOMReady.

cc @sdougbrown @nilnilnil 