### PR TITLE
duckduckgo-ocaml

### DIFF
--- a/share/site/duckduckgo/api.tx
+++ b/share/site/duckduckgo/api.tx
@@ -195,6 +195,7 @@ vs
 <li><a href="https://github.com/lukewendling/ddg-api">Node.js module</a> by <a href="http://lukewendling.com">Luke Wendling</a>
 <li><a href="https://github.com/jawerty/node-ddg">Node.js wrapper</a> by <a href="http://jawerty.github.io/">Jared Wright</a>
 <li><a href="https://github.com/timkly/DuckDuckGo.Net">.Net Library</a> by <a href="http://tk.id.au/">Tim Kelly</a>
+<li><a href="https://github.com/mwhittaker/duckduckgo-ocaml">OCaml Library</a> by <a href="http://mwhittaker.github.io/">Michael Whittaker</a>
 <li>If you make another supporting library, we'll add it here!
 </span>
 </ul>


### PR DESCRIPTION
I was reading through the DuckDuckGo API site and noticed that the "supporting library integrations" section didn't have any OCaml libraries. So, I decided to [write one and I put it on Github](https://github.com/mwhittaker/duckduckgo-ocaml)! I was hoping it could be added to the "supporting library integrations" section :D