### PR TITLE
Add div for top red border on static sites

### DIFF
--- a/share/site/duckduckgo/base.tx
+++ b/share/site/duckduckgo/base.tx
@@ -12,6 +12,7 @@
   <body id="pg-<: $f.filebase :>" class="page-<: $f.filebase :><: if $homepage { :> body--home<: } :>">
 	<: include "head_js.tx" :>
 	<div class="site-wrapper <: if $homepage { :> site-wrapper--home<: } else { :> site-wrapper--static<: } :>  js-site-wrapper">
+      <div class="site-wrapper-border"></div>
 	<: if !$no_wrapper { :> 
 	  <: if !$no_header { include "header.tx" } :>
 	  <div id="content_wrapper" class="content-wrap">

--- a/share/site/duckduckgo/base.tx
+++ b/share/site/duckduckgo/base.tx
@@ -12,7 +12,7 @@
   <body id="pg-<: $f.filebase :>" class="page-<: $f.filebase :><: if $homepage { :> body--home<: } :>">
 	<: include "head_js.tx" :>
 	<div class="site-wrapper <: if $homepage { :> site-wrapper--home<: } else { :> site-wrapper--static<: } :>  js-site-wrapper">
-      <div class="site-wrapper-border"></div>
+		<div class="site-wrapper-border"></div>
 	<: if !$no_wrapper { :> 
 	  <: if !$no_header { include "header.tx" } :>
 	  <div id="content_wrapper" class="content-wrap">


### PR DESCRIPTION
We changed from `:before` pseudo element to actual div element so it would work in IE8, but the static pages weren't also updated.

@nilnilnil 
cc @sdougbrown 