### PR TITLE
Conditional Header Border

### DIFF
--- a/share/site/duckduckgo/base.tx
+++ b/share/site/duckduckgo/base.tx
@@ -12,7 +12,9 @@
   <body id="pg-<: $f.filebase :>" class="page-<: $f.filebase :><: if $homepage { :> body--home<: } :>">
 	<: include "head_js.tx" :>
 	<div class="site-wrapper <: if $homepage { :> site-wrapper--home<: } else { :> site-wrapper--static<: } :>  js-site-wrapper">
+	<: if !$hero_header { :>
 		<div class="site-wrapper-border"></div>
+	<: } :>
 	<: if !$no_wrapper { :> 
 	  <: if !$no_header { include "header.tx" } :>
 	  <div id="content_wrapper" class="content-wrap">


### PR DESCRIPTION
We don't want the fixed-position header border to appear on pages where we have a 'hero' section.  This just conditionally includes it now.

cc @bsstoner 