### PR TITLE
Styleguide - SERP Styles

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -348,6 +348,7 @@ sub pages {{
 		no_cw => 1,
 		hero_header => 1,
 		hero_header_text => 1,
+		css_serp => 1,
 		icons => ['loupe','menu','region','star','music','marker','home','more','eye','check','cry','clock','user','users','comment','plus','minus','close','close-bold','move','grid','uploaded','upload','download','prev','next','left','right','down','up','left-big','right-big','check-sign','right-sign','left-sign','more-sign','less-sign'],
 		colors => ['white','silver-light','silver','silver-dark','platinum-light','platinum','platinum-dark','platinum-darker','grey-light','grey','grey-dark','slate-light','slate','red-light','red','red-dark','blue-light','blue','blue-dark','green','gold','purple',],
 	},

--- a/share/site/duckduckgo/meta/base.tx
+++ b/share/site/duckduckgo/meta/base.tx
@@ -7,6 +7,9 @@
 
 <link rel="stylesheet" href="<: $ENV.DDG_DYNAMIC_CSS_FILE || '/style.css' :>" type="text/css">
 <link rel="stylesheet" href="<: $ENV.DDG_DYNAMIC_CSS_2_FILE || '/static.css' :>" type="text/css">
+<: if $css_serp { :>
+<link rel="stylesheet" href="<: $ENV.DDG_DYNAMIC_CSS_3_FILE || '/serp.css' :>" type="text/css">
+<: } :>
 
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="16x16 24x24 32x32 64x64"/>
 <link rel="apple-touch-icon" href="/assets/icons/meta/DDG-iOS-icon_60x60.png"/>


### PR DESCRIPTION
We need to include the new serp stylesheet on the styleguide for everything to work correctly. :smile: 

Requires an internal PR to init `DDG_DYNAMIC_CSS_3_FILE` on deploy.