### PR TITLE
Eric/quiet

### DIFF
--- a/lib/DDG/App/Publisher.pm
+++ b/lib/DDG/App/Publisher.pm
@@ -67,6 +67,17 @@ option tmpl_dir => (
 	predicate => 1,
 );
 
+=attr quiet
+
+Don't print Text::XSlate warnings
+
+=cut
+
+option quiet => (
+	is => 'ro',
+	predicate => 1,
+);
+
 =method run
 
 This method gets executed for the run of the publisher
@@ -91,12 +102,13 @@ sub run {
 			: die "Require a target path or DDG_PUBLISHER_TARGETDIR set";
 	my $dir = dir($target)->absolute;
 	my $publisher = DDG::Publisher->new(
+		$self->has_quiet ? ( quiet => $self->quiet ) : (),
 		$self->has_compression ? ( compression => $self->compression ) : (),
 		$self->has_dryrun ? ( dryrun => $self->dryrun ) : (),
 		$self->has_site_only ? ( site_classes => [$self->site_only] ) : (),
 		$self->has_tmpl_dir ? ( extra_template_dirs => [$self->tmpl_dir] ) : (),
 	);
-	print "Publishing to ".$dir." ... \n";
+	print "Publishing to ".$dir."\n";
 	my $count;
 	eval {
 		$count = $publisher->publish_to($dir);

--- a/lib/DDG/Publisher.pm
+++ b/lib/DDG/Publisher.pm
@@ -6,7 +6,6 @@ use Path::Class;
 use Class::Load ':all';
 use IO::All -utf8;
 use HTML::Packer;
-use Term::ProgressBar::Simple;
 use JSON;
 use File::Path qw(make_path);
 

--- a/lib/DDG/Publisher.pm
+++ b/lib/DDG/Publisher.pm
@@ -6,7 +6,7 @@ use Path::Class;
 use Class::Load ':all';
 use IO::All -utf8;
 use HTML::Packer;
-use String::ProgressBar;
+use Term::ProgressBar::Simple;
 use JSON;
 use File::Path qw(make_path);
 
@@ -105,6 +105,17 @@ has dryrun => (
 	predicate => 1,
 );
 
+=attr quiet
+
+Don't print Text::XSlate warnings
+
+=cut
+
+has quiet => (
+	is => 'ro',
+	predicate => 1,
+);
+
 sub BUILD {
 	my ( $self ) = @_;
 	$self->sites;
@@ -135,17 +146,9 @@ sub publish_to {
 		#
 
 		for my $dir (values %{$site->dirs}) {
-			print "\n".(ref $site).$dir->web_path."\n\n";
+			print "  - " . (ref $site) . substr($dir->web_path, 0, -1) . "\n";
 			my @files = values %{$dir->fullpath_files};
-			my $progress = String::ProgressBar->new(
-				max => scalar @files,
-				length => 50,
-			);
-			my $i = 0;
 			for (sort { $a->fullpath cmp $b->fullpath } @files) {
-				$i++;
-				$progress->update($i);
-				$progress->write;
 				my $real_file = file($target_dir,$site->key,$_->fullpath)->absolute;
 				$real_file->dir->mkpath unless -f $real_file->dir->absolute->stringify;
 				my $content = $_->content;
@@ -169,7 +172,6 @@ sub publish_to {
 				io($real_file->stringify)->print($content);
 				$count++;
 			}
-			print "\n";
 		}
 
 		#

--- a/lib/DDG/Publisher/File.pm
+++ b/lib/DDG/Publisher/File.pm
@@ -195,9 +195,6 @@ sub _build_content {
 	# explicit getting out no_base for template decision later
 	my $no_base = defined $vars{no_base} && $vars{no_base};
 
-#	use Data::Dumper;
-#	warn Dumper($vars{'ENV'});
-
 	#
 	# Gathering the save data for the data files generation
 	#

--- a/lib/DDG/Publisher/SiteRole.pm
+++ b/lib/DDG/Publisher/SiteRole.pm
@@ -155,6 +155,17 @@ has template_engine => (
 	builder => 1,
 );
 
+=attr quiet
+
+Don't print Text::XSlate warnings
+
+=cut
+
+has quiet => (
+    is => 'ro',
+    default => sub { 0 },
+);
+
 sub _build_template_engine {
 	my ( $self ) = @_;
 	my $site_template_root = dir(dist_dir('DDG-Publisher'),'site',$self->key)->stringify;
@@ -171,7 +182,7 @@ sub _build_template_engine {
 			return mark_raw($translation);
 		};
 	}
-	return Text::Xslate->new(
+    my %args = (
 		#
 		# Include share/site/$key and share/core as template directories
 		#
@@ -205,7 +216,9 @@ sub _build_template_engine {
 				return defined($_[0]) ? CORE::lc($_[0]) : undef;
 			},
 		},
-	);
+    );
+    $args{warn_handler} = sub {} if $self->publisher->quiet;
+	return Text::Xslate->new(%args);
 }
 
 1;


### PR DESCRIPTION
I'm working on replacing deploy.pl with rex.  However `rex deploy:base` is noisy.  This quiets things down.

1. I removed the progress bar.  Every update to progress bar causes another line to be written to the log file. 
2. I added a --quiet option to ignore Text::Xslate warnings because:
  - These warnings are useless since (I think) we ignore them anyway.  
  - Also (correct me if I'm wrong @jbarrett), but the community website has a check for these, so its not needed here.

cc @malbin 