### PR TITLE
Fix for DDH docs breadcrumb, make it hierarchical, nix dukgo.com

### DIFF
--- a/share/site/duckduckhack/doc.tx
+++ b/share/site/duckduckhack/doc.tx
@@ -12,7 +12,7 @@
 				<div id="duckduckhack-body">
 					<div class="breadcrumb-nav">
 						<div class="breadcrumbs">
-							 <a href="https://dukgo.com/">Home</a> &gt; <a href="http://duckduckhack.com">DuckDuckHack</a> &gt; <: if $category { $category :> &gt; <: } $title :> 
+							 <a href="https://duck.co/">Home</a> &gt; <a href="https://duck.co/duckduckhack/">DuckDuckHack</a> &gt; <: if $category { $category :> &gt; <: } $title :> 
 						</div>												
 					</div>
 					<div class="gw  gw--sm  mg-bottom">

--- a/share/site/duckduckhack/doc.tx
+++ b/share/site/duckduckhack/doc.tx
@@ -12,7 +12,7 @@
 				<div id="duckduckhack-body">
 					<div class="breadcrumb-nav">
 						<div class="breadcrumbs">
-							 <a href="https://duck.co/">Home</a> &gt; <a href="https://duck.co/duckduckhack/">DuckDuckHack</a> &gt; <: if $category { $category :> &gt; <: } $title :> 
+							 <a href="/">Home</a> &gt; <a href="/duckduckhack">DuckDuckHack</a> &gt; <: if $category { $category :> &gt; <: } $title :> 
 						</div>												
 					</div>
 					<div class="gw  gw--sm  mg-bottom">


### PR DESCRIPTION
@moollaza @DavidMascio 

Well, this is where the breadcrumb lives. Took duckduckhack.com out of the second level, made both links point to duck.co.