### PR TITLE
Spread Page - Hide T-Shirt Section

### DIFF
--- a/share/site/duckduckgo/spread.tx
+++ b/share/site/duckduckgo/spread.tx
@@ -48,7 +48,7 @@
 		</div>
 	</div>
 </div>
-<div class="blk  blk--arr  blk--alt">
+<div class="blk  blk--arr  blk--alt  is-hidden  js-spread-callout">
 	<div class="spread-callout">
 		<noscript>
 			<img class="spread-img" title="Will it have a duck on it?  Only time will tell..." src="/assets/spread/t-shirt.png" />


### PR DESCRIPTION
We're going to be more selective when we display this section, so we're hiding it by default.  If someone is clever enough to find it in open source or in the page source then we probably want to give them a t-shirt anyway. :smile: 

Requires an internal PR for the javascript to display it again.

to @zekiel 
cc @bsstoner @andrey-p 