### PR TITLE
simplify css in DDH Docs <head>, content.css contains everything needed

### DIFF
--- a/share/site/duckduckhack/inc/head_doc.tx
+++ b/share/site/duckduckhack/inc/head_doc.tx
@@ -1,8 +1,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-<: for ['/ddgc_static/css/reset','/ddgc_static/css/litestrap','/ddgc_static/css/_ls/abstracts','/ddgc_static/css/font-face','/ddgc_static/css/font-awesome','/ddgc_static/css/modals','/ddgc_static/css/forms-n-buttons','/static/css/account','/ddgc_static/css/content','/ddgc_static/css/main'] -> $css { :>
-	<link rel="stylesheet" media="screen, projection, handheld" href="<: $css :>.css" />
-<: } :>
+<link rel="stylesheet" media="screen, projection, handheld" href="/static/css/content.css" />
 <meta name="viewport" content="width=100, initial-scale=1.0" />
 
 <meta name="twitter:site" value="@duckco" />


### PR DESCRIPTION
This is only used when testing the DDH Docs locally via `duckpan publisher`. This does _not_ affect production.

Tested and working locally with `duckpan publisher --duckduckhack http://duck.co`

/cc @jagtalon @jbarrett 
