### PR TITLE
cleanup distini and .travis.yml; Remove Dzil Travis plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
   - dzil listdeps | grep -ve '^\W' | cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
-  - cpanm --quiet --notest --mirror --mirror http://duckpan.org App::DuckPAN
+  - cpanm --quiet --notest App::DuckPAN
   - duckpan DDG
   - duckpan DDGC::Locale::DuckduckgoDuckduckgo
   - duckpan DDGC::Locale::DuckduckgoDontbubbleus

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 ---
+sudo: false
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-  - rm .travis.yml
   - git config --global user.name "Dist Zilla Plugin TravisCI"
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
-  - cpanm  --quiet   --notest  App::DuckPAN
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-installed
+  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --skip-installed
+  - cpanm --quiet --notest App::DuckPAN
   - duckpan DDG
   - duckpan DDGC::Locale::DuckduckgoDuckduckgo
   - duckpan DDGC::Locale::DuckduckgoDontbubbleus
   - duckpan DDGC::Locale::DuckduckgoDonttrackus
 language: perl
 perl:
-  - 5.16
-  - 5.14
+  - '5.16'
 script:
   - dzil smoke --release --author

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --skip-installed
-  - cpanm --quiet --notest App::DuckPAN
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - dzil listdeps | grep -ve '^\W' | cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - cpanm --quiet --notest --mirror --mirror http://duckpan.org App::DuckPAN
   - duckpan DDG
   - duckpan DDGC::Locale::DuckduckgoDuckduckgo
   - duckpan DDGC::Locale::DuckduckgoDontbubbleus

--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,8 @@ directory = xt/
 directory = ex/
 directory = inc/
 
+[PodWeaver]
+
 [Git::NextVersion]
 version_regexp = ^(.+)$
 [PkgVersion]

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,8 @@ copyright_year   = 2012
 index_base_url = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
+[AutoPrereqs]
+
 [GatherDir]
 [PruneCruft]
 [ManifestSkip]
@@ -20,7 +22,6 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 [ConfirmRelease]
 [UploadToDuckPAN]
 [MetaJSON]
-[MetaYAML]
 
 [MetaNoIndex]
 directory = t/
@@ -33,53 +34,7 @@ version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
 [GithubMeta]
-[Test::EOL]
-trailing_whitespace = 0
-
 [@Git]
 tag_format = %v
-
-[PodWeaver]
-
-[Prereqs]
-IO::All = 0.46
-Text::Xslate = 1.5017
-Locale::Simple = 0.008
-File::ShareDir::ProjectDistDir = 0.3.2
-MooX = 0.101
-Class::Load = 0.20
-Path::Class = 0.26
-HTML::Packer = 1.004001
-JavaScript::Packer = 1.006003
-CSS::Packer = 1.002001
-MooX::Options = 3.71
-Config::INI = 0.019
-JavaScript::Value::Escape = 0
-JavaScript::Minifier::XS = 0
-String::ProgressBar = 0.03
-JSON = 2.57
-; DuckDuckHack docs.
-IPC::Run = 0
-Markdent = 0.24
-File::Path = 0
-File::Find = 0
-Text::Trim = 0
-; Debugging.
-DDP = 0
-; Travis
-Dist::Zilla::Plugin::TravisCI = 0.003
-
-[Prereqs / TestRequires]
-Test::EOL = 0
-Test::More = 0.98
-Test::LoadAllModules = 0.021
-
-[TravisCI]
-perl_version = 5.16
-perl_version = 5.14
-extra_dep = App::DuckPAN
-after_install = duckpan DDG
-after_install = duckpan DDGC::Locale::DuckduckgoDuckduckgo
-after_install = duckpan DDGC::Locale::DuckduckgoDontbubbleus
-after_install = duckpan DDGC::Locale::DuckduckgoDonttrackus
-
+[Git::Push]
+push_to = origin master


### PR DESCRIPTION
The .travis.yml was giving @bsstoner errors this morning. I noticed it still has the older (problematic) setup. The should clean things up a bit. Also moves the builds to use the newer, faster Travis containers.

/cc @zachthompson 