### PR TITLE
Homepage Logo Tooltip

### DIFF
--- a/share/site/duckduckgo/_logo_homepage.tx
+++ b/share/site/duckduckgo/_logo_homepage.tx
@@ -1,8 +1,6 @@
 		<div class="logo-wrap--home">
-			<a id="logo_homepage_link" class="logo_homepage" title="About DuckDuckGo" href="/about">About DuckDuckGo</a>
+			<a id="logo_homepage_link" class="logo_homepage" href="/about">
+				About DuckDuckGo
+				<span class="logo_homepage__tt">Duck it!</span>
+			</a>
 		</div>
-<!--
-		<div class="logo-wrap--home">
-			<a id="logo_homepage_link" class="logo_homepage  logo_homepage--resetthenet" title="Reset the Net" href="https://www.resetthenet.org/" target="_new">Reset the Net</a>
-		</div>
-		//-->

--- a/share/site/duckduckgo/header.tx
+++ b/share/site/duckduckgo/header.tx
@@ -3,7 +3,7 @@
 	<div id="header" class="header  cw">
 		<div class="header__search-wrap">
 			<a href="/" class="header__logo-wrap">
-				<span class="header__logo">DuckDuckGo</span>
+				<span class="header__logo">DuckDuckGo<span class="header__logo__tt">Duck it!</span></span>
 			</a>
 			<div class="header__content  header__search  search-wrap--header">
 				<form id="search_form" class="search  search--header  js-search-form" name="x" action="<: if $absolute_search_url { :>https://duckduckgo.com<: } :>/">


### PR DESCRIPTION
Requires an internal PR for the tooltip styling.

I also removed an old special logo that we just had commented out.  I don't really think we want that showing as a comment in production anymore.

to @yegg 
