### PR TITLE
use the https URL for git clone

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -62,7 +62,7 @@ sub _build_source_dir {
 		} else {
 			local $CWD = $cache_dir;
 			run [
-				'git', 'clone', 'git@github.com:duckduckgo/duckduckgo-documentation.git'
+				'git', 'clone', 'https://github.com/duckduckgo/duckduckgo-documentation.git'
 			], \$in, \$out, \$err, timeout(60) or die "$err (error $?) $out";
 		}
 	}


### PR DESCRIPTION
This git clone is failing with our new github.com changes. Using https we can avoid using our github.com keys just to checkout this repo.

cc: @malbin @marcantonio 