### PR TITLE
Wrapper script to load static assets from your dev instance

### DIFF
--- a/bin/dev_server.sh
+++ b/bin/dev_server.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+[ "$DDG_WHOAMI" == "" ] && export DDG_WHOAMI=$( whoami )
+[ "$DDG_HOST"   == "" ] && export DDG_HOST=$( printf 'https://%s.duckduckgo.com' $DDG_WHOAMI )
+
+[ "$DDG_DYNAMIC_SETTINGS_JS_FILE" == "" ] && \
+    export DDG_DYNAMIC_SETTINGS_JS_FILE=$( printf '%s/set.js' $DDG_HOST )
+[ "$DDG_DYNAMIC_JS_FILE"          == "" ] && \
+    export DDG_DYNAMIC_JS_FILE=$( printf '%s/base.js' $DDG_HOST )
+[ "$DDG_DYNAMIC_JS_2_FILE"        == "" ] && \
+    export DDG_DYNAMIC_JS_2_FILE=$( printf '%s/serp.js' $DDG_HOST )
+
+[ "$DDG_DYNAMIC_CSS_FILE"   == "" ] && \
+    export DDG_DYNAMIC_CSS_FILE=$( printf '%s/style.css' $DDG_HOST )
+[ "$DDG_DYNAMIC_CSS_2_FILE" == "" ] && \
+    export DDG_DYNAMIC_CSS_2_FILE=$( printf '%s/static.css' $DDG_HOST )
+[ "$DDG_DYNAMIC_CSS_2_FILE" == "" ] && \
+    DDG_DYNAMIC_CSS_3_FILE=$( printf '%s/serp.css' $DDG_HOST )
+
+echo $DDG_WHOAMI;
+
+duckpan publisher

--- a/dist.ini
+++ b/dist.ini
@@ -39,7 +39,13 @@ trailing_whitespace = 0
 [@Git]
 tag_format = %v
 
+[FileFinder::ByName / BinNotShell]
+dir = bin
+skip = .*\.sh$
+
 [PodWeaver]
+finder = :InstallModules
+finder = BinNotShell
 
 [Prereqs]
 IO::All = 0.46

--- a/share/core/head_js.tx
+++ b/share/core/head_js.tx
@@ -1,8 +1,8 @@
-<script type="text/javascript">settings_js_version = "<: $asset_path :><: $ENV.DDG_DYNAMIC_SETTINGS_JS_FILE || '/set.js' :>";</script>
+<script type="text/javascript">settings_js_version = "<: $ENV.DDG_DYNAMIC_SETTINGS_JS_FILE || $asset_path ~ '/set.js' :>";</script>
 <script type="text/javascript" src="/locales/<: $f.locale :>/LC_MESSAGES/<: $s.locale_domain :>+sprintf+gettext+locale-simple.<: $locale_package_version :>.js"></script>
-<script type="text/javascript" src="<: $asset_path :><: $ENV.DDG_DYNAMIC_JS_FILE || '/base.js' :>"></script>
+<script type="text/javascript" src="<: $ENV.DDG_DYNAMIC_JS_FILE || $asset_path ~ '/base.js' :>"></script>
 <: if $js_include_g { :>
-<script type="text/javascript" src="<: $asset_path :><: $ENV.DDG_DYNAMIC_JS_2_FILE || '/serp.js' :>"></script>
+<script type="text/javascript" src="<: $ENV.DDG_DYNAMIC_JS_2_FILE || $asset_path ~ '/serp.js' :>"></script>
 <: } :>
 <: if !$js_skip_init { :>
 <script type="text/javascript">

--- a/share/site/duckduckgo/head_js.tx
+++ b/share/site/duckduckgo/head_js.tx
@@ -1,11 +1,11 @@
 <script type="text/javascript">
-var settings_js_version = "<: $asset_path :><: $ENV.DDG_DYNAMIC_SETTINGS_JS_FILE || '/set.js' :>",
+var settings_js_version = "<: $ENV.DDG_DYNAMIC_SETTINGS_JS_FILE || $asset_path ~ '/set.js' :>",
     locale = "<: $f.locale :>";
 </script>
 <script type="text/javascript" src="<: $asset_path :>/locales/<: $f.locale :>/LC_MESSAGES/<: $s.locale_domain :>+sprintf+gettext+locale-simple.<: $locale_package_version :>.js"></script>
-<script type="text/javascript" src="<: $asset_path :><: $ENV.DDG_DYNAMIC_JS_FILE || '/base.js' :>"></script>
+<script type="text/javascript" src="<: $ENV.DDG_DYNAMIC_JS_FILE || $asset_path ~ '/base.js' :>"></script>
 <: if $js_include_g { :>
-<script type="text/javascript" src="<: $asset_path :><: $ENV.DDG_DYNAMIC_JS_2_FILE || '/serp.js' :>"></script>
+<script type="text/javascript" src="<: $ENV.DDG_DYNAMIC_JS_2_FILE || $asset_path ~ '/serp.js' :>"></script>
 <: } :>
 <: if !$js_skip_init { :>
 <script type="text/javascript">

--- a/share/site/duckduckhack/inc/head.tx
+++ b/share/site/duckduckhack/inc/head.tx
@@ -7,8 +7,8 @@
 
 <link rel="canonical" href="https://duckduckhack.com">
 
-<link rel="stylesheet" href="<: $asset_path :><: $ENV.DDG_DYNAMIC_CSS_FILE || '/style.css' :>" type="text/css">
-<link rel="stylesheet" href="<: $asset_path :><: $ENV.DDG_DYNAMIC_CSS_2_FILE || '/static.css' :>" type="text/css">
+<link rel="stylesheet" href="<: $ENV.DDG_DYNAMIC_CSS_FILE || $asset_path ~ '/style.css' :>" type="text/css">
+<link rel="stylesheet" href="<: $ENV.DDG_DYNAMIC_CSS_2_FILE || $asset_path ~ '/static.css' :>" type="text/css">
 
 <meta name="twitter:site" value="@duckduckhack">
 <meta name="twitter:url" value="https://duckduckhack.com">


### PR DESCRIPTION
Just running `bin/dev_server.sh` should load latest built js and css from your dev instance.

If you need to override the default user, do e.g.

```bash
DDG_WHOAMI=brian bin/dev_server.sh
```

You can see other variables in dev_server.sh.

This also makes changes to static file paths in header templates. Instead of prepending `$asset_path` in every case, it is done just for the fallback (so should kick in on build or when environment variables are not set.

Cc: @bsstoner @andrey-p @yegg 