### PR TITLE
Speeding up duckduckhack.com development

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -143,6 +143,7 @@ sub get_nav {
 my $dir_output = '/usr/local/ddg/www-static/duckduckhack.com/tmp';
 
 sub pages {
+	return {} if $ENV{DDH_SKIP_DOCS_BUILD};
 	my $self = shift;
 
 	my %pages = ();


### PR DESCRIPTION
So the reason this one site is so sluggish is it ties up starman server instances while it clones and builds the docs repo.

With this change you can set an environment variable to skip all the docs operations, so instead of:

```
duckpan publisher
```

You would run:

```
DDH_SKIP_DOCS_BUILD=1 duckpan publisher
```

You would, of course, leave this out if you need to build and evaluate docs :smile:

### Timings:

#### Before:

![41 seconds!](http://jbrt.org/ddg/publisher_ddh_requests_before.png)

#### After:

![2.5 seconds!](http://jbrt.org/ddg/publisher_ddh_requests_after.png)

The number to pay attention to is '/' - generation goes from 10 seconds to 1. Still not quite as zippy as the other sites in publisher but better if you need a fast feedback loop.

After the first request, the static files (which you can see taking around 25 seconds to serve in the before shot) are served almost instantly. I just left these in to show the improvement in initial request time too. It's really all about '/'.

Cc: @moollaza @alohaas @russellholt 