### PR TITLE
fixed broken link to regex cheat sheet github link

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -168,7 +168,7 @@ sub pages {
 			img => 'regex',
 			tab => 'Regex',
 			user => 'mintsoft',
-			link => 'https://duckduckgo.com/?q=regex+cheat+sheet&ia=answer',
+			link => 'https://duckduckgo.com/?q=regex+cheat+sheet&ia=cheatsheet',
 		},{
 			text => "With the help of you and our community, every search can have an Instant Answer.",
 			img => 'recipes',
@@ -193,7 +193,7 @@ sub pages {
 			desc => 'Quickly see regex syntax',
 			user => 'mintsoft',
 			link => 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/share/goodie/cheat_sheets/json/regex.json',
-			example_link => 'https://duckduckgo.com/?q=regex+cheat+sheet&t=ffab&ia=answer',
+			example_link => 'https://duckduckgo.com/?q=regex+cheat+sheet&t=ffab&ia=cheatsheet',
 		},{
 			name => 'Timer',
 			desc => 'Set a timer for any occasion',

--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -192,7 +192,7 @@ sub pages {
 			name => 'Regex cheat sheet',
 			desc => 'Quickly see regex syntax',
 			user => 'mintsoft',
-			link => 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/RegexCheatSheet.pm',
+			link => 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/share/goodie/cheat_sheets/json/regex.json',
 			example_link => 'https://duckduckgo.com/?q=regex+cheat+sheet&t=ffab&ia=answer',
 		},{
 			name => 'Timer',


### PR DESCRIPTION
Hello,
Came across a link that isn't working anymore.
The original github link for the Regex cheat sheet gives a user an 404 message.
Greetings, Paul