### PR TITLE
Remove "untranslated" warning

### DIFF
--- a/share/site/duckduckgo/api.tx
+++ b/share/site/duckduckgo/api.tx
@@ -15,8 +15,6 @@ pre {
 
 <div id="special_page_header"><: l('Instant Answer API') :></div>
 
-<: include "untranslated.tx" :>
-
 <div style="margin-bottom:30px;"></div>
 Our Instant Answer API gives you free access to many of our instant answers like:
 <a href="/?q=valley+forge+national+park&ia=about">topic summaries</a> 


### PR DESCRIPTION
I think this is an unnecessary distraction. We don't have a similar message in most (all?) other English pages so will probably be OK without it here.