### PR TITLE
Programming Mission Onboarding Updates

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -24,7 +24,7 @@ sub pages {
 		asset_path => 'ddg',
 		js_page_type => 'DDH',
 		hero_slides => [{
-			text => "Help us make %sDuckDuckGo%s, the best search engine for programmers.",
+			text => "Help us make %sDuckDuckGo%s the best search engine for programmers.",
 			img => 'regex',
 			tab => 'Regex',
 			user => 'mintsoft',

--- a/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckhack/Root.pm
@@ -24,29 +24,11 @@ sub pages {
 		asset_path => 'ddg',
 		js_page_type => 'DDH',
 		hero_slides => [{
-			text => "Welcome to %sDuckDuckHack%s, an open source community changing the future of search.",
-			img => 'soundcloud',
-			tab => 'Audio',
-			user => 'jdan',
-			link => 'https://duckduckgo.com/?q=songs+by+tycho&ia=audio',
-		},{
-			text => "Getting what you search for in few or zero clicks makes a great search experience.",
+			text => "Help us make %sDuckDuckGo%s, the best search engine for programmers.",
 			img => 'regex',
 			tab => 'Regex',
 			user => 'mintsoft',
 			link => 'https://duckduckgo.com/?q=regex+cheat+sheet&ia=cheatsheet',
-		},{
-			text => "With the help of you and our community, every search can have an Instant Answer.",
-			img => 'recipes',
-			tab => 'Recipes',
-			user => 'bsstoner',
-			link => 'https://duckduckgo.com/?q=reese%27s+cookie+recipes&ia=recipes',
-		},{
-			text => "Use the Web's best sources for a specific topic or build an Instant Answer from scratch!",
-			img => 'movies',
-			tab => 'Movies',
-			user => 'killerfish',
-			link => 'https://duckduckgo.com/?q=currently+in+theaters&ia=in_theaters&iai=0',
 		}],
 		foot_useful => [{
 			name => 'Fuel Economy',

--- a/share/site/duckduckhack/index_content.tx
+++ b/share/site/duckduckhack/index_content.tx
@@ -1,7 +1,4 @@
  <div class="blk  blk--hero  blk--hero--alt  js-hero-slides"><a class="anchor ddh-anchor js-anchor" name="top"></a>
-	<div class="ddh-gqh js-gqh">
-        <a class="ddh-gqh__link tx-clr--white" target="_gqhblog" href="https://duck.co/blog/post/239/global-quack-hack-2-details"><: l("Join us for our global Quack & Hack Event on January 30, 2016!") :></a>
-    </div>
     <div class="cw--c  ddh-hero">
 		<div class="ddh-hero-slides">
 		<: for $hero_slides -> $h { :><div class="ddh-hero-slides__item  js-hero-text">
@@ -10,13 +7,9 @@
 				</h1>
 			</div><: } :>
 		</div>
-		<a href="#start" class="ddh-hero__btn  btn  btn--wire--hero  js-anchor-link"><: l("Get Started") :></a>
+		<a href="https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53" class="ddh-hero__btn  btn  btn--wire--hero"><: l("Get Started") :></a>
 	</div>
 	<div class="ddh-hero-slides--img">
-		<span class="ddh-hero-slides__nav-wrap">
-			<span class="ddh-hero-slides__nav  nav  nav--hero  nav--prev  js-hero-slides-prev"></span>
-			<span class="ddh-hero-slides__nav  nav  nav--hero  nav--next  js-hero-slides-next"></span>
-		</span>
 		<div class="ddh-hero-slides__wrap">
 			<: for $hero_slides -> $h { :>
 				<div class="ddh-hero-slides__img-wrap  js-hero-img  no-js__hide">

--- a/share/site/duckduckhack/index_content.tx
+++ b/share/site/duckduckhack/index_content.tx
@@ -23,67 +23,6 @@
 		</div>
 	</div>
 </div>
-<!-- <div id="power-of-ias" class="blk tx-clr--white ddh ddh--ias">
-    <div class="cw--c">
-        <h2 class="ddh__title"><: l("Power of Instant Answers") :></h2>
-        <p class="ddh__sub"><: l("Instant Answers are tailor-made for specific queries") :></p>
-        <div class="gw ddh--ias__items">
-            <div class="g third ddh--ias__item tx--17">
-                <h3 class="ddh--ias__number tx-bld js-ddh-num--live">630</h3>
-                <span class="ddh--ias__status"><: l("Live") :></span>
-                <p class="ddh--ias__desc"><: l("Explore the variety of Instant Answers live on DuckDuckGo, from real-time APIs to full text search.") :></p>
-                <a class="ddh--ias__link tx-bld" target="_live" href="https://duck.co/ia"><i class="ddh--ias__icon fa fa-chevron-circle-right"></i><: l("View All") :></a>
-            </div>
-            <div class="g third ddh--ias__item tx--17">    
-                <h3 class="ddh--ias__number tx-bld js-ddh-num--development">182</h3>
-                <span class="ddh--ias__status"><: l("In Development") :></span>
-                <p class="ddh--ias__desc"><: l("The DuckDuckHack Dev Pipeline helps the community view and manage Instant Answers in development.") :></p> 
-                <a class="ddh--ias__link tx-bld" target="_development" href="https://duck.co/ia/dev/pipeline"><i class="ddh--ias__icon fa fa-chevron-circle-right"></i><: l("Dev Pipeline") :></a>
-            </div>
-            <div class="g third ddh--ias__item tx--17">  
-                <h3 class="ddh--ias__number tx-bld js-ddh-num--beta">39</h3>
-                <span class="ddh--ias__status"><: l("In Beta") :></span>
-                <p class="ddh--ias__desc"><: l("Before they go live, Instant Answers are installed on DuckDuckGo's beta server for the community to test.") :></p>
-                <a class="ddh--ias__link tx-bld" target="_beta" href="https://beta.duckduckgo.com/?q=installed&ia=iatesting&iax=1"><i class="ddh--ias__icon fa fa-chevron-circle-right"></i><: l("Beta Server") :></a>
-            </div>
-        </div>
-    </div>
-</div>
-<div id="get-involved" class="blk  blk--alt  ddh"><a class="anchor ddh-anchor js-anchor" name="start"></a>
-	<div class="cw--c">
-		<h2 class="ddh__title"><: l("Get involved!") :></h2>
-		<p class="ddh__sub"><: l("Take a look at what you can do to help!") :></p>
-		<div class="ddh__split">
-			<div class="ddh__split__item  half">
-				<div class="ddh-cta">
-					<noscript>
-						<img src="images/develop.png" class="ddh-cta__icon" />
-					</noscript>
-					<img src="" data-src="images/develop" class="ddh-cta__icon  js-lazysvg  no-js__hide" />
-					<h4 class="ddh-cta__title"><: l("Create an Instant Answer") :></h4>
-					<p class="ddh-cta__sub"><: l("Build something new") :></p>
-					
-					<p class="ddh-cta__text"><: l("For Developers, creating an IA is fun and rewarding. Utilize great data sources to improve search results for the topics you care most about.") :></p>
-					<a target="_develop" href="https://duck.co/ia/new_ia" class="ddh-cta__btn  btn  btn--primary"><: l("Develop") :></a>
-				</div>
-			</div>
-			<span class="ddh__split__divide"><: l("OR") :></span>
-			<div class="ddh__split__item  half">
-				<div class="ddh-cta">
-					<noscript>
-						<img src="images/bugfix.png" class="ddh-cta__icon" />
-					</noscript>
-					<img src="" data-src="images/bugfix" class="ddh-cta__icon  js-lazysvg  no-js__hide" />
-					<h4 class="ddh-cta__title"><: l("Review and Fix Bugs") :></h4>
-					<p class="ddh-cta__sub"><: l("Learn by squashing bugs") :></p>
-					
-					<p class="ddh-cta__text"><: l("Fixing issues is a great way to get involved in the community and contribute while learning. Help improve Instant Answers you like and find inspiration for your own.") :></p>
-					<a target="_fix" href="https://duck.co/ia/dev" class="ddh-cta__btn  btn  btn--primary"><: l("Fix") :></a>
-				</div>
-			</div>
-		</div>
-	</div>
-</div> -->
 <div id="get-help" class="blk ddh ddh--help">
     <div class="cw--c">
         <h2 class="ddh__title"><: l("Need Help Getting Started?") :></h2>

--- a/share/site/duckduckhack/index_content.tx
+++ b/share/site/duckduckhack/index_content.tx
@@ -23,7 +23,7 @@
 		</div>
 	</div>
 </div>
-<div id="power-of-ias" class="blk tx-clr--white ddh ddh--ias">
+<!-- <div id="power-of-ias" class="blk tx-clr--white ddh ddh--ias">
     <div class="cw--c">
         <h2 class="ddh__title"><: l("Power of Instant Answers") :></h2>
         <p class="ddh__sub"><: l("Instant Answers are tailor-made for specific queries") :></p>
@@ -83,7 +83,7 @@
 			</div>
 		</div>
 	</div>
-</div>
+</div> -->
 <div id="get-help" class="blk ddh ddh--help">
     <div class="cw--c">
         <h2 class="ddh__title"><: l("Need Help Getting Started?") :></h2>


### PR DESCRIPTION
Immediate changes to duckduckhack that will improve the onboarding process for the programming mission by funneling users to a single point, removing distractions:

- Link "Get Started" to the Programming Mission Overview 
- Update carousel text
- Hide power of IAs and develop/fix sections for now because both links present distractions from the Programming Mission
- Remove Programming Mission banner
- Change the image to the regex cheat sheet to highlight programming IAs

cc: @zac @russellholt @abeyang 

![pm_onboarding_revision](https://cloud.githubusercontent.com/assets/4480279/17787038/b3d9c652-65b1-11e6-9f65-8e34dd3b6014.png)
