### PR TITLE
Fixed broken link

### DIFF
--- a/share/site/duckduckgo/search_box.tx
+++ b/share/site/duckduckgo/search_box.tx
@@ -68,7 +68,7 @@ function new_code() {
 
   code = d.getElementById("code_frame");
   code.src = '/search.html' + params;
-  YAHOO.util.Dom.setStyle(code,'height',height); 
+  YAHOO.util.Dom.setStyle(code,'height',height);
 }
 new_code();
 </script>
@@ -76,7 +76,7 @@ new_code();
 <ul>
 <li>Width: <input type="text" style="width:40px;" onkeyup="new_code_width=this.value;new_code();">px (The example above uses 408 pixels)
 <div style="margin-bottom:7px;"></div>
-<li>Duck logo: 
+<li>Duck logo:
 
 <input type="radio" name="duck" checked onchange="if (this.checked) new_code_duck=''; else new_code_duck='';new_code();"> Off
 &nbsp; <input type="radio" name="duck" onchange="if (this.checked) new_code_duck='yes'; else new_code_duck='';new_code();"> On
@@ -95,10 +95,10 @@ new_code();
 <div style="margin-bottom:7px;"></div>
 <li>Prefill: <input type="text" style="width:200px;" onkeyup="new_code_prefill=this.value;new_code();" value="Search DuckDuckGo"> ex: Search DuckDuckGo
 <div style="margin-bottom:7px;"></div>
-<li>Autofocus: 
+<li>Autofocus:
 <input type="radio" name="focus" checked onchange="if (this.checked) new_code_focus=''; else new_code_focus='';new_code();"> Off
 &nbsp; <input type="radio" name="focus" onchange="if (this.checked) new_code_focus='yes'; else new_code_focus='';new_code();"> On (If On, the cursor will automatically be in the search box when the page loads)
-<div style="margin-bottom:7px;"></div>                                        
+<div style="margin-bottom:7px;"></div>
 </ul>
 
 
@@ -106,8 +106,7 @@ new_code();
 You can use our <a href="/params.html">URL params</a> and use DuckDuckGo settings to further customize the results pages. However, please see the guidelines at the top of that page before doing so.
 
 <div style="margin-bottom:15px;"></div>
-You can also make and style your own like the search box at the bottom of the <a href="http://daringfireball.net/#SiteSearch">Daring Fireball blog</a>. There is also a great <a href="http://hardik.org/blog/stylising-duckduckgo-site-search/">a blog post</a> on how to do this.
+You can also make and style your own like the search box at the bottom of the <a href="http://daringfireball.net/#SiteSearch">Daring Fireball blog</a>. There is also a great <a href="https://web.archive.org/web/20160623174219/http://hardik.org/blog/stylising-duckduckgo-site-search/">blog post (archived)</a> on how to do this.
 
 
 </span>
-


### PR DESCRIPTION
The original site has been taken offline so linking to Wayback Machine's archive instead.
(and my editor removes whitespace automatically)

Originally [reported on Twitter](https://twitter.com/deepdeviant/status/768523280487686145)