### PR TITLE
Added social media links to About page

### DIFF
--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -199,7 +199,7 @@ Smarter search without the tracking.
 				</label>
 			</div>
 		</form>
-	    <p class="text--secondary">Follow us on social media.</p>
-	    <p class="text--secondary"><a href="https://twitter.com/duckduckgo">Twitter</a> | <a href="https://www.facebook.com/duckduckgo">Facebook</a> | <a href="https://www.linkedin.com/company/duck-duck-go">LinkedIn</a></p>
+	    <p class="text--secondary">Keep in touch via social media.</p>
+	    <p class="text--secondary"><a href="https://twitter.com/duckduckgo">Twitter</a> | <a href="https://reddit.com/r/duckduckgo">Reddit</a></p>
 	</div>
 </div>

--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -162,8 +162,8 @@ Smarter search without the tracking.
 </div>
 <div class="abt  blk  blk--arr">
 	<div class="cw--c"><a class="anchor" name="newsletter"></a>
-		<h2 class="abt__title">Our Newsletter</h2>
-		<p class="abt__sub">Stay up to date with all things DuckDuckGo.</p>
+		<h2 class="abt__title">Stay up to Date</h2>
+		<p class="abt__sub">Join our newsletters for all things DuckDuckGo.</p>
 		<form class="frm--newsletter  abt__newsletter" action="https://flash.duckduckgo.com/e.js" method="post" name="y">
 			<input type="hidden" name="add" value="1" />
 			<input type="text" placeholder="Your email address" class="frm__input" name="from" />
@@ -172,26 +172,26 @@ Smarter search without the tracking.
 				<label class="frm__label" for="add">
 					<input class="frm__label__chk" type="checkbox" id="add" name="add" checked="checked">
 					<span class="frm__label__txt">
-						Newsletter 
+						Newsletter
 						<span class="frm--newsletter__frq">Monthly</span>
 					</span>
 				</label>
 				<label class="frm__label" for="add2">
-					<input class="frm__label__chk" type="checkbox" id="add2" name="add2"> 
+					<input class="frm__label__chk" type="checkbox" id="add2" name="add2">
 					<span class="frm__label__txt">
 						Beta
 						<span class="frm--newsletter__frq">New stuff</span>
 					</span>
 				</label>
 				<label class="frm__label" for="add3">
-					<input class="frm__label__chk" type="checkbox" id="add3" name="add3"> 
+					<input class="frm__label__chk" type="checkbox" id="add3" name="add3">
 					<span class="frm__label__txt">
 						Spread
 						<span class="frm--newsletter__frq">Promotions</span>
 					</span>
 				</label>
 				<label class="frm__label" for="add4">
-					<input class="frm__label__chk" type="checkbox" id="add4" name="add4"> 
+					<input class="frm__label__chk" type="checkbox" id="add4" name="add4">
 					<span class="frm__label__txt">
 						Privacy
 						<span class="frm--newsletter__frq">Education</span>
@@ -199,5 +199,7 @@ Smarter search without the tracking.
 				</label>
 			</div>
 		</form>
+	    <p class="text--secondary">Follow us on social media.</p>
+	    <p class="text--secondary"><a href="https://twitter.com/duckduckgo">Twitter</a> | <a href="https://www.facebook.com/duckduckgo">Facebook</a> | <a href="https://www.linkedin.com/company/duck-duck-go">LinkedIn</a></p>
 	</div>
 </div>

--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -199,7 +199,12 @@ Smarter search without the tracking.
 				</label>
 			</div>
 		</form>
-	    <p class="text--secondary">Keep in touch via social media.</p>
-	    <p class="text--secondary"><a href="https://twitter.com/duckduckgo">Twitter</a> | <a href="https://reddit.com/r/duckduckgo">Reddit</a></p>
+        <div class="abt__social-media">
+            <p class="abt__social-media__cta text--secondary">Keep in touch via social media.</p>
+            <p class="abt__social-media__sites text--secondary">
+                <a href="https://twitter.com/duckduckgo" class="no-visited">Twitter</a> |
+                <a href="https://reddit.com/r/duckduckgo" class="no-visited">Reddit</a>
+            </p>
+        </div>
 	</div>
 </div>


### PR DESCRIPTION
Following suggestions by @andrey-p and @chrismorast in https://app.asana.com/0/inbox/42485752355997/248995145166035/249079438970887

<img width="600" alt="about-page_social-media" src="https://cloud.githubusercontent.com/assets/94173/22205853/0005682a-e1bc-11e6-93a0-63a2ab006bf8.png">
