### PR TITLE
remove 'example message' and hyperlink the correct string.

### DIFF
--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -171,7 +171,7 @@ Smarter search without the tracking.
 			<input type="email" placeholder="Your email address" class="frm__input" name="email" />
 			<input type="submit" value="Subscribe" class="frm__btn  btn  btn--primary--alt" />
 		</form>
-		<p class="abt__sub t-xs">Your email address will not be shared or associated with anonymous searches. [<a href="https://spreadprivacy.com/google-search-history-4bae7619407d">Example message</a>]</p>
+		<p class="abt__sub t-xs">[<a href="https://spreadprivacy.com/google-search-history-4bae7619407d">Your email address will not be shared or associated with anonymous searches.</a>]</p>
         <div class="abt__social-media">
             <p class="abt__social-media__cta text--secondary">Keep in touch via social media.</p>
             <p class="abt__social-media__sites text--secondary">


### PR DESCRIPTION
After installing the duckduckgo Firefox extension I noticed that one of the links that pop-up when DDG asks for the user e-mail, is an "[Example message]" string. This PR aims to remove the "[Example message]" and hyperlink the string "Your email address will not be shared or associated with anonymous searches." You can see the message here -> https://imgur.com/PzvhEvi