### PR TITLE
About Page: Remove the hack section

### DIFF
--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -87,16 +87,6 @@ Smarter search without the tracking.
 <br>Join the community and help improve DuckDuckGo.</p>
 		<div class="abt__row">
 			<div class="abt__key  third  half--screen-m">
-				<a class="abt__key__title-link" href="http://duckduckhack.com">
-					<noscript>
-						<img class="abt__key__icon" src="/assets/about/icons/build.png" />
-					</noscript>
-					<img class="abt__key__icon  js-lazysvg  no-js__hide" src="" data-src="/assets/about/icons/build">
-					<h3 class="abt__key__title">Hack</h3>
-				</a>
-				<p>Join the DuckDuckGo community to help people find what they're looking for in fewer clicks! Extend our search engine with better instant answers on your favorite topics.</p>
-				<a class="abt__key__link" href="http://duckduckhack.com">Hack DuckDuckGo</a>
-			</div><div class="abt__key  third  half--screen-m">
 				<a class="abt__key__title-link" href="/spread">
 					<noscript>
 						<img class="abt__key__icon" src="/assets/about/icons/love.png" />


### PR DESCRIPTION
Since DuckDuckHack is winding down, we're removing the hack section in the about page.