### PR TITLE
Add in 2018 donations, remove CrowdRise CTA

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -1,5 +1,6 @@
 package DDG::Publisher::Site::Duckduckgo::Root;
 
+use strict;
 use MooX;
 
 with qw(

--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -324,7 +324,7 @@ sub pages {{
 			year => '2018',
 			total => '$500,000',
 			theme => 'Privacy Challenge',
-			snippet => 'Help us set a new standard of trust online by supporting privacy organizations through our <a href="https://www.crowdrise.com/duckduckgoprivacychallenge">2018 Privacy Challenge</a>. We\'ll increase the impact of your donations through matching and prizes up to $500,000!',
+			snippet => 'For our eighth year of donations, we organized and donated to a <a href="https://www.crowdrise.com/duckduckgoprivacychallenge">privacy crowdfunding campaign</a> that benefited these twenty organizations that share our vision of raising the standard of trust online.',
 			donations => {
 				col1 => [
 					{recipient => 'Access Now', url => 'https://www.crowdrise.com/access-now1'},
@@ -337,9 +337,9 @@ sub pages {{
 					{recipient => 'Freenet Project', url => 'https://www.crowdrise.com/freenet-project'},
 					{recipient => 'Internet Freedom Festival', url => 'https://www.crowdrise.com/internet-freedom-festival'},
 					{recipient => 'Let’s Encrypt', url => 'https://www.crowdrise.com/lets-encrypt'},
+					{recipient => 'New Media Rights', url => 'https://www.crowdrise.com/new-media-rights'},
 				],
 				col2 => [
-					{recipient => 'New Media Rights', url => 'https://www.crowdrise.com/new-media-rights'},
 					{recipient => 'Open Source Technology Improvement Fund (OSTIF)', url => 'https://www.crowdrise.com/ostif1'},
 					{recipient => 'Privacy Rights Clearinghouse', url => 'https://www.crowdrise.com/privacy-rights-clearinghouse1'},
 					{recipient => 'Restore the 4th', url => 'https://www.crowdrise.com/restore-the-4th'},

--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -321,6 +321,38 @@ sub pages {{
 		copyright_text => 'Privacy, simplified.',
 		js_page_type => 'Donations',
 		yearly_donations => [{
+			year => '2018',
+			total => '$500,000',
+			theme => 'Privacy Challenge',
+			snippet => 'Help us set a new standard of trust online by supporting privacy organizations through our <a href="https://www.crowdrise.com/duckduckgoprivacychallenge">2018 Privacy Challenge</a>. We\'ll increase the impact of your donations through matching and prizes up to $500,000!',
+			donations => {
+				col1 => [
+					{recipient => 'Access Now', url => 'https://www.crowdrise.com/access-now1'},
+					{recipient => 'American Civil Liberties Union (ACLU)', url => 'https://www.crowdrise.com/aclu-foundation'},
+					{recipient => 'Bits of Freedom', url => 'https://www.crowdrise.com/bits-of-freedom1'},
+					{recipient => 'Center for Democracy & Technology', url => 'https://www.crowdrise.com/center-for-democracy-and-technology'},
+					{recipient => 'Demand Progress', url => 'https://www.crowdrise.com/demand-progress'},
+					{recipient => 'Emerald Onion', url => 'https://www.crowdrise.com/emerald-onion'},
+					{recipient => 'Fight for the Future', url => 'https://www.crowdrise.com/fight-for-the-future'},
+					{recipient => 'Freedom of the Press Foundation', url => 'https://www.crowdrise.com/freedom-of-the-press-foundation1'},
+					{recipient => 'Freenet Project', url => 'https://www.crowdrise.com/freenet-project'},
+					{recipient => 'Internet Freedom Festival', url => 'https://www.crowdrise.com/internet-freedom-festival'},
+					{recipient => 'Let’s Encrypt', url => 'https://www.crowdrise.com/lets-encrypt'},
+				],
+				col2 => [
+					{recipient => 'New Media Rights', url => 'https://www.crowdrise.com/new-media-rights'},
+					{recipient => 'Open Source Technology Improvement Fund (OSTIF)', url => 'https://www.crowdrise.com/ostif1'},
+					{recipient => 'Privacy Rights Clearinghouse', url => 'https://www.crowdrise.com/privacy-rights-clearinghouse1'},
+					{recipient => 'Restore the 4th', url => 'https://www.crowdrise.com/restore-the-4th'},
+					{recipient => 'Riseup Labs', url => 'https://www.crowdrise.com/riseup-labs1'},
+					{recipient => 'Tails', url => 'https://www.crowdrise.com/tails-live'},
+					{recipient => 'The Calyx Institute', url => 'https://www.crowdrise.com/the-calyx-institute'},
+					{recipient => 'Tor Project', url => 'https://www.crowdrise.com/tor-project'},
+					{recipient => 'Terms of Service; Didn’t Read', url => 'https://www.crowdrise.com/tosdr'},
+					{recipient => 'World Privacy Forum', url => 'https://www.crowdrise.com/world-privacy-forum1'},
+				]
+			}
+		},{
 			year => '2017',
 			total => '$400,000',
 			theme => 'Privacy Education',

--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -328,7 +328,6 @@ sub pages {{
 			donations => {
 				col1 => [
 					{recipient => 'Access Now', url => 'https://www.crowdrise.com/access-now1'},
-					{recipient => 'American Civil Liberties Union (ACLU)', url => 'https://www.crowdrise.com/aclu-foundation'},
 					{recipient => 'Bits of Freedom', url => 'https://www.crowdrise.com/bits-of-freedom1'},
 					{recipient => 'Center for Democracy & Technology', url => 'https://www.crowdrise.com/center-for-democracy-and-technology'},
 					{recipient => 'Demand Progress', url => 'https://www.crowdrise.com/demand-progress'},

--- a/share/site/duckduckgo/donations.tx
+++ b/share/site/duckduckgo/donations.tx
@@ -11,7 +11,7 @@
 	<a class="donations__cta__btn__wrap js-anchor-link" href="#donations-list">
 		<img class="donations__cta__btn" src="/assets/donations/angle-down.svg">
 	</a>
-	<p class="donations__cta__text">Over <b>$800,000</b> in DuckDuckGo privacy donations</p>
+	<p class="donations__cta__text">Over <b>$1,300,000</b> in DuckDuckGo privacy donations</p>
 </div>
 
 <a name="donations-list" class="anchor js-anchor"></a>

--- a/share/site/duckduckgo/donations.tx
+++ b/share/site/duckduckgo/donations.tx
@@ -8,11 +8,10 @@
 
 <img class="donations__img whole" src="/assets/about/hiker.svg" aria-hidden="true">
 <div class="blk donations__cta">
-  <div class="cw--c">
-    <h1 class="donations__cta__header">Join the DuckDuckGo 2018 <br>Privacy Challenge!</h1>
-    <p class="donations__cta__subheader">Help DuckDuckGo set a new standard of trust online by joining the 2018 Privacy Challenge. We'll increase the impact of your donations by matching up to $500,000!</p>
-    <a href="https://www.crowdrise.com/duckduckgoprivacychallenge" class="donations__btn btn btn--primary tx-up js-donations-cta" data-source="cta">Learn More</a>
-  </div>
+	<a class="donations__cta__btn__wrap js-anchor-link" href="#donations-list">
+		<img class="donations__cta__btn" src="/assets/donations/angle-down.svg">
+	</a>
+	<p class="donations__cta__text">Over <b>$800,000</b> in DuckDuckGo privacy donations</p>
 </div>
 
 <a name="donations-list" class="anchor js-anchor"></a>


### PR DESCRIPTION
## Description

- Removes CrowdRise campaign CTA from hero
- Adds 2018 CrowdRise participants to list

**Note:** Requires internal CSS changes