### PR TITLE
PortableApps: Update Q-Dir, Firefox versions; Remove retina images (not used)

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
@@ -29,22 +29,22 @@ sub pages {{
 		product => {
 			name => 'Mozilla Firefox',
 			asset_path => 'mozilla-firefox',
-			version => '60.0',
+			version => '60.0.1',
 			category => 'Browsers',
 			url => 'https://portableapps.com/apps/internet/firefox_portable',
 			dl => {
 				size => '75MB',
-				filename => 'FirefoxPortable/FirefoxPortable_60.0_English.paf.exe'
+				filename => 'FirefoxPortable/FirefoxPortable_60.0.1_English.paf.exe'
 			},
 			inst_size => '274MB',
 			summary => "Mozilla Firefox® is a fast, full-featured web browser that's easy to use. It has lots of great features including popup-blocking, tabbed-browsing, integrated search, improved privacy features, automatic updating and more. Plus, thanks to the PortableApps.com launcher bundled in the Mozilla Firefox, Portable Edition, it leaves no personal information behind on the machine you run it on, so you can take your favorite browser along with all your favorite bookmarks and extensions with you wherever you go. Firefox Portable is a dual-mode 32-bit and 64-bit app, ensuring Firefox runs as fast as possible on every PC.",
 			details => {
 				'Publisher' => 'Mozilla & PortableApps.com (John T. Haller)',
-				'Date Updated' => '2018-05-09',
+				'Date Updated' => '2018-05-17',
 				'System Requirements' => 'Windows 7, 8, 10 & WINE',
 				'License' => 'Open Source (MPL/GPL/LGPL under Mozilla EULA)',
 				'Source' => 'Launcher (included), Firefox',
-				'MD5 Hash' => '2fa01402ce48e666f3aad7360cfe101b (English)',
+				'MD5 Hash' => 'c1183c3240fcde3bbcb7240835570f7f (English)',
 			}
 		}
 	},

--- a/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
@@ -79,10 +79,10 @@ sub pages {{
 	"portableapps" => sub {
 		%page_defaults,
 
-		title => 'PortableApps Platform',
+		title => 'PortableApps.com Platform',
 		product => {
 			is_platform => 1,
-			name => 'PortableApps',
+			name => 'PortableApps.com',
 			asset_path => 'portableapps',
 			version => '15.0.1',
 			category => 'Utilities',

--- a/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
@@ -56,22 +56,22 @@ sub pages {{
 		product => {
 			name => 'Q-Dir',
 			asset_path => 'q-dir',
-			version => '7.01',
+			version => '7.03',
 			category => 'Utilities',
 			url => 'https://portableapps.com/apps/development/q-dir-portable',
 			dl => {
 				size => '1MB',
-				filename => 'Q-DirPortable/Q-DirPortable_7.01.paf.exe'
+				filename => 'Q-DirPortable/Q-DirPortable_7.03.paf.exe'
 			},
-			inst_size => '2MB',
+			inst_size => '3MB',
 			summary => "Q-Dir (the Quad Explorer) makes your files and folder easy to manage. It provides fast and easy access to your hard disks, network folders, USB-Sticks, floppy disks and other storage devices. The 32-bit and 64-bit versions of Q-Dir are included and the correct one automatically used.",
 			details => {
 				'Publisher' => 'Nenad Hrg & PortableApps.com',
-				'Date Updated' => '2018-04-30',
+				'Date Updated' => '2018-05-17',
 				'System Requirements' => 'Windows XP, Vista, 7, 8, 10 & WINE',
 				'License' => 'Freeware (Personal and business use)',
 				'Source' => 'Launcher (included), PortableApps.com Installer',
-				'MD5 Hash' => 'e0e5336d9f4fffc901287010e0765ea4'
+				'MD5 Hash' => '2e347ea81edb811d294e500bb463123d'
 			}
 		}
 	},

--- a/share/site/duckduckgo/product_page.tx
+++ b/share/site/duckduckgo/product_page.tx
@@ -16,7 +16,7 @@
                     </div>
                 </div>
 
-                <img class="pp__image js-lazyretina mg-top--double" data-src="/assets/software/screenshots/<: $product.asset_path :>.jpg">
+                <img class="pp__image js-lazyimg mg-top--double" data-src="/assets/software/screenshots/<: $product.asset_path :>.jpg">
 
                 <div class="pp__summary text-left">
                     <h2 class="pp__summary__title">App Summary</h2>
@@ -56,21 +56,21 @@
 
                 <!-- TODO: Replace blog-card with media-card -->
                 <a href="/software/portableapps" class="js-static-link blog-card bg-clr--white" data-id="0">
-                    <img class="blog-card__image js-lazyretina" data-src="/assets/software/thumbnails/portableapps.jpg">
+                    <img class="blog-card__image js-lazyimg" data-src="/assets/software/thumbnails/portableapps.jpg">
                     <div class="blog-card__content">
                         <h3 class="blog-card__title">PortableApps.com Platform</h3>
                         <p class="blog-card__topic tx-up">Utilities</p>
                     </div>
                 </a>
                 <a href="/software/q-dir-portable" class="js-static-link blog-card bg-clr--white" data-id="1">
-                    <img class="blog-card__image js-lazyretina" data-src="/assets/software/thumbnails/q-dir.jpg">
+                    <img class="blog-card__image js-lazyimg" data-src="/assets/software/thumbnails/q-dir.jpg">
                     <div class="blog-card__content">
                         <h3 class="blog-card__title">Q-Dir, Portable Edition</h3>
                         <p class="blog-card__topic tx-up">Utilities</p>
                     </div>
                 </a>
                 <a href="/software/mozilla-firefox-portable" class="js-static-link blog-card bg-clr--white" data-id="2">
-                    <img class="blog-card__image js-lazyretina" data-src="/assets/software/thumbnails/mozilla-firefox.jpg">
+                    <img class="blog-card__image js-lazyimg" data-src="/assets/software/thumbnails/mozilla-firefox.jpg">
                     <div class="blog-card__content">
                         <h3 class="blog-card__title">Mozilla Firefox, Portable Edition</h3>
                         <p class="blog-card__topic tx-up">Browsers</p>


### PR DESCRIPTION
# Description
- Updates Firefox for v60.0.1
- Updates Q-Dir to v7.03
- Adds ".com" to PortableApps title
- Removed retina images (not being used on desktop)