### PR TITLE
Update Portable Apps Platform to v15.0.2

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
@@ -84,12 +84,12 @@ sub pages {{
 			is_platform => 1,
 			name => 'PortableApps.com',
 			asset_path => 'portableapps',
-			version => '15.0.1',
+			version => '15.0.2',
 			category => 'Utilities',
 			url => 'https://portableapps.com/download',
 			dl => {
 				size => '5MB',
-				filename => 'pacplatform/PortableApps.com_Platform_Setup_15.0.1.paf.exe'
+				filename => 'pacplatform/PortableApps.com_Platform_Setup_15.0.2.paf.exe'
 			},
 			inst_size => '12MB',
 			summary => "The PortableApps.com Platform™ is a full-featured portable software system that ties all your portable apps together and lets you build your own custom portable app suite for use in your synced cloud folder, on your local PC, or on a portable USB drive.",
@@ -99,7 +99,7 @@ sub pages {{
 				'System Requirements' => 'Windows 10, Windows 8.1, Windows 8, Windows 7, Windows Vista, Windows XP, Linux, Unix, BSD, etc via Wine & Mac OS X via CrossOver, Wineskin, WineBottler, PlayOnMac',
 				'License' => 'Free / Open Source (GPL, some MIT, some CC images, trademarks and trade dress not included)',
 				'Source' => 'PortableApps.com Platform (Menu, App Store, etc)',
-				'MD5 Hash' => '69d2cc00eca10a517793671eda48a4a0'
+				'MD5 Hash' => 'c02fc058be0e9985cc56aa4073a207af'
 			}
 		}
 	}

--- a/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Software.pm
@@ -25,7 +25,6 @@ sub pages {{
 	"mozilla-firefox-portable" => sub {
 		%page_defaults,
 
-		title => 'Mozilla Firefox, Portable Edition',
 		product => {
 			name => 'Mozilla Firefox',
 			asset_path => 'mozilla-firefox',
@@ -52,7 +51,6 @@ sub pages {{
 	"q-dir-portable" => sub {
 		%page_defaults,
 
-		title => 'Q-Dir, Portable Edition',
 		product => {
 			name => 'Q-Dir',
 			asset_path => 'q-dir',
@@ -79,10 +77,9 @@ sub pages {{
 	"portableapps" => sub {
 		%page_defaults,
 
-		title => 'PortableApps.com Platform',
 		product => {
 			is_platform => 1,
-			name => 'PortableApps.com',
+			name => 'PortableApps.com Platform',
 			asset_path => 'portableapps',
 			version => '15.0.2',
 			category => 'Utilities',

--- a/share/site/duckduckgo/product_page.tx
+++ b/share/site/duckduckgo/product_page.tx
@@ -2,7 +2,7 @@
     <div class="cw--c pp__top">
         <div class="gw">
             <div class="g whole left-col">
-                <h1 class="pp__title text-center"><: $product.name :><: if $product.is_platform {:> Platform <: } else { :>, Portable Edition<: } :></h1>
+                <h1 class="pp__title text-center"><: $product.name :><: if !$product.is_platform { :>, Portable Edition<: } :></h1>
 
                 <hr class="pp__hr"/>
 


### PR DESCRIPTION
# Description
- Updates version number
- Removes unused 'Title' property for hash
- Added 'Platform' to name so it's always presented with 'PortableApps.com'
