### PR TITLE
Standardize copyright text; Simplify static page defaults; 

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -9,16 +9,19 @@ with qw(
 
 sub path { '/' }
 
+my %page_defaults = (
+	no_content_internal => 1,
+	no_spacer => 1,
+	no_footer_arrow => 1,
+	about_footer => 1,
+	copyright_footer => 1,
+);
+
 sub pages {{
 	about => sub {
-		about_footer => 1,
-		copyright_footer => 1,
-		copyright_text => 'Privacy, simplified.',
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
 		hero_header => 1,
 		no_hero_header_icon => 1,
-		no_cw => 1,
 		js_page_type => 'About',
 		ddg_events => [{
 			date => 'February 29, 2008',
@@ -215,11 +218,8 @@ sub pages {{
 		}]
 	},
 	bang => sub {
-		copyright_footer => 1,
-		nav_footer => 1,
-		no_footer_arrow => 1,
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
+
 		no_cw => 1,
 		hero_header => 1,
 		hero_header_text => 1,
@@ -237,9 +237,8 @@ sub pages {{
 		js_include_g => 1,
 	},
 	styleguide => sub {
-		copyright_footer => 1,
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
+
 		no_cw => 1,
 		hero_header => 1,
 		hero_header_text => 1,
@@ -257,7 +256,6 @@ sub pages {{
 		js_page_type => 'Spread',
 	},
 	iframe => sub {
-		copyright_footer => 0,
 		no_content_internal => 1,
 		no_spacer => 1,
 		no_cw => 1,
@@ -296,42 +294,24 @@ sub pages {{
 		no_spacer => 1,
 		no_content_internal => 1,
 		js_skip_init => 1
-		},
+	},
 	app => sub {
-		nav_footer => 0,
-		no_footer_arrow => 1,
-		copyright_footer => 0,
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
 		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'Addons',
-		about_footer => 1,
 		copyright_footer => 1,
-		copyright_text => 'Privacy, simplified.',
-	    },
-	    newsletter => sub {
-		nav_footer => 0,
-		no_footer_arrow => 1,
-		no_content_internal => 1,
-		no_spacer => 1,
+	},
+	newsletter => sub {
+		%page_defaults,
 		hero_header => 1,
 		no_hero_header_icon => 0,
 		js_page_type => 'Newsletter',
-		about_footer => 1,
-		copyright_footer => 1,
-		copyright_text => 'Privacy, simplified.',
-	    },
+	},
 	donations => sub {
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
 		hero_header => 1,
 		no_hero_header_icon => 1,
-		nav_footer => 0,
-		no_footer_arrow => 1,
-		about_footer => 1,
-		copyright_footer => 1,
-		copyright_text => 'Privacy, simplified.',
 		js_page_type => 'Donations',
 		yearly_donations => [{
 			year => '2018',
@@ -500,12 +480,7 @@ sub pages {{
 		}],
 	},
 	press => sub {
-		about_footer => 1,
-		no_footer_arrow => 1,
-		copyright_footer => 1,
-		copyright_text => 'Privacy, simplified.',
-		no_content_internal => 1,
-		no_spacer => 1,
+		%page_defaults,
 		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'Press',

--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -10,9 +10,9 @@ with qw(
 sub path { '/' }
 
 my %page_defaults = (
+	hero_header => 1,
 	no_content_internal => 1,
 	no_spacer => 1,
-	no_footer_arrow => 1,
 	about_footer => 1,
 	copyright_footer => 1,
 );
@@ -20,7 +20,6 @@ my %page_defaults = (
 sub pages {{
 	about => sub {
 		%page_defaults,
-		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'About',
 		ddg_events => [{
@@ -219,9 +218,7 @@ sub pages {{
 	},
 	bang => sub {
 		%page_defaults,
-
 		no_cw => 1,
-		hero_header => 1,
 		hero_header_text => 1,
 		js_page_type => 'Bang',
 		js_bang_version => 1
@@ -238,9 +235,7 @@ sub pages {{
 	},
 	styleguide => sub {
 		%page_defaults,
-
 		no_cw => 1,
-		hero_header => 1,
 		hero_header_text => 1,
 		css_serp => 1,
 		icons => ['alert','arrow-down','arrow-left','arrow-right','arrow-top','arrow-up','check','check-sign','circle','clock','close','close-bold','cloudsave','comment','cry','down','download','eye','football','grid','heart','home','info','left','left-big','left-sign','less-sign','loupe','marker','menu','minus','more','more-sign','move','music','news','next','pause','play','plus','prev','region','right','right-big','right-sign','star','swap','t-down','t-left','t-right','t-up','up','upload','uploaded','user','users',],
@@ -297,20 +292,17 @@ sub pages {{
 	},
 	app => sub {
 		%page_defaults,
-		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'Addons',
 		copyright_footer => 1,
 	},
 	newsletter => sub {
 		%page_defaults,
-		hero_header => 1,
 		no_hero_header_icon => 0,
 		js_page_type => 'Newsletter',
 	},
 	donations => sub {
 		%page_defaults,
-		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'Donations',
 		yearly_donations => [{
@@ -481,7 +473,6 @@ sub pages {{
 	},
 	press => sub {
 		%page_defaults,
-		hero_header => 1,
 		no_hero_header_icon => 1,
 		js_page_type => 'Press',
 	}

--- a/share/core/footer_copyright.tx
+++ b/share/core/footer_copyright.tx
@@ -4,7 +4,7 @@
 				<: if $copyright_text { :>
 					<: l($copyright_text) :>
 				<: } else { :>
-					<: l("The search engine that doesn't track you.") :>
+					<: l('DuckDuckGo. Privacy, simplified') :>
 				<: } :>
 			</p>
 	</div>

--- a/share/core/footer_copyright.tx
+++ b/share/core/footer_copyright.tx
@@ -4,7 +4,7 @@
 				<: if $copyright_text { :>
 					<: l($copyright_text) :>
 				<: } else { :>
-					<: l('DuckDuckGo. Privacy, simplified') :>
+					<: l('Privacy, simplified') :>
 				<: } :>
 			</p>
 	</div>

--- a/share/site/duckduckgo/base.tx
+++ b/share/site/duckduckgo/base.tx
@@ -63,5 +63,5 @@
 		</div> <!-- content_wrapper //-->
 	<: } :>
 	</div> <!-- site-wrapper -->
- </body>
+</body>
 </html>


### PR DESCRIPTION
## Description
- Updated default copyright footer text to `DuckDuckGo. Privacy, simplifed` -- which we've used on all recent new/updated pages.
- Created a `%page_defaults` hash to DRY up standard static page definitions in `Root.pm`

## Testing
- Deploy changes
- Check the following. Pages that have a nav footer should now have the about footer. Pages without footers should remain the same. Pages with copyright footer should all have the same text.
    - https://jag.duckduckgo.com/about -- unchanged
    - https://jag.duckduckgo.com/api -- unchanged
    - https://jag.duckduckgo.com/app -- unchanged
    - https://jag.duckduckgo.com/bang -- about footer + new copyright text
    - https://jag.duckduckgo.com/donations -- new copyright text
    - https://jag.duckduckgo.com/duckduckbot -- unchanged
    - https://jag.duckduckgo.com/duckduckpreview -- unchanged
    - https://jag.duckduckgo.com/feedback -- unchanged
    - https://jag.duckduckgo.com/iframe -- unchanged
    - https://jag.duckduckgo.com/install -- unchanged
    - https://jag.duckduckgo.com/newbang -- unchanged
    - https://jag.duckduckgo.com/newsletter -- unchanged
    - https://jag.duckduckgo.com/params -- unchanged
    - https://jag.duckduckgo.com/press -- unchanged
    - https://jag.duckduckgo.com/privacy -- new copyright text
    - https://jag.duckduckgo.com/search_box -- unchanged
    - https://jag.duckduckgo.com/settings -- unchanged
    - https://jag.duckduckgo.com/spread -- new copyright text
    - https://jag.duckduckgo.com/styleguide -- unchanged
    - https://jag.duckduckgo.com/yahoo_static -- unchanged