### PR TITLE
Use classnames to show/hide bang form subcategory field

### DIFF
--- a/share/site/duckduckgo/newbang.tx
+++ b/share/site/duckduckgo/newbang.tx
@@ -5,11 +5,11 @@ var i;
 function fill_subcat(i){
 d.y.bang_subcat.options.length = 0;
 if (i > 0) {
-    d.y.bang_subcat.style.visibility = 'visible';
+    d.y.bang_subcat.className = '';
 }
 switch(i){
 case 0:
-  d.y.bang_subcat.style.visibility = 'hidden';
+  d.y.bang_subcat.className = 'invisible';
   break;
 case 1:
   d.y.bang_subcat.options[0] =new Option('<: js(l('Choose subcategory')) :>','')


### PR DESCRIPTION
## Description

I think this page was previously lacking some of our shared styles. We rejigged the static styles recently so they were added.

The subcategory dropdown was using `.invisible` as a class name, but didn't remove it. `.invisible` now has `visibility: hidden !important` so it trumps the styles changed via JS.

## Testing

1. Get this running on your machine
2. Go to https://konrad.duckduckgo.com/newbang
3. Scroll down to where it says "bang category" - the subcategory field should be hidden
4. Pick a bang category - the subcategory field should appear