### PR TITLE
Apply translation function to page title

### DIFF
--- a/share/site/duckduckgo/meta/index.tx
+++ b/share/site/duckduckgo/meta/index.tx
@@ -1,4 +1,4 @@
-<: include "meta/title.tx" { title => 'DuckDuckGo — Privacy, simplified.' } :>
+<: include "meta/title.tx" { title => 'DuckDuckGo — ' ~ l('Privacy, simplified.') } :>
 
 <meta property="og:description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">
 <meta name="description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">


### PR DESCRIPTION
## Description

Since we have translations for the title, let's use them.

## Testing

- Open the front page and add request param ?kad=de_DE
- Page title should include slogan in German