### PR TITLE
Change phrasing on bang page

### DIFF
--- a/share/site/duckduckgo/bang.tx
+++ b/share/site/duckduckgo/bang.tx
@@ -11,7 +11,7 @@
 <div class="bang bang--about blk blk--alt blk--arr">
     <div class="cw--c bang--about__cw">
         <div class="bang--about__content">
-            <h2 class="bang--about__snippet">What are bangs?</h2>
+            <h2 class="bang--about__title">What are bangs?</h2>
             <p class="bang--about__text">Bangs are shortcuts that quickly take you to search results on other sites. For example, when you know you want to search on another site like Wikipedia or Amazon, our bangs get you there fastest. A search for <a class="js-about-bang-link" data-bang="w" data-query="filter bubble" href="#">!w filter bubble</a> will take you directly to Wikipedia.</p>
             <p class="bang--about__text">Remember, though, because your search is actually taking place on that other site, you are subject to that site’s policies, including its data collection practices.</p>
             <p class="bang--about__text">We’ve had bangs since 2008 as part of <a target="_blank" href="https://en.wikipedia.org/wiki/Shebang_(Unix)">our geek roots</a>. Now we have <a href="#bangs-list">more than 10,000 !bangs</a> and you can even <a href="/newbang">submit your own</a>.</p>

--- a/share/site/duckduckgo/bang.tx
+++ b/share/site/duckduckgo/bang.tx
@@ -5,7 +5,6 @@
         </noscript>
         <img class="bang--hero__icon js-lazysvg no-js__hide" src="" data-src="/assets/bang/bang" />
         <h1 class="bang--hero__title">Say hello to bangs.</h1>
-        <h2 class="bang--hero__snippet">Search thousands of sites directly from DuckDuckGo.</h2>
     </div>
 </div>
 <div class="bang bang--about blk blk--alt blk--arr">

--- a/share/site/duckduckgo/bang.tx
+++ b/share/site/duckduckgo/bang.tx
@@ -11,7 +11,7 @@
     <div class="cw--c bang--about__cw">
         <div class="bang--about__content">
             <h2 class="bang--about__title">What are bangs?</h2>
-            <p class="bang--about__text">Bangs are shortcuts that quickly take you to search results on other sites. For example, when you know you want to search on another site like Wikipedia or Amazon, our bangs get you there fastest. A search for <a class="js-about-bang-link" data-bang="w" data-query="filter bubble" href="#">!w filter bubble</a> will take you directly to Wikipedia.</p>
+            <p class="bang--about__text">Bangs are shortcuts that quickly take you to search results on other sites. For example, when you know you want to search on another site like Wikipedia or Amazon, our bangs get you there fastest. A search for <a class="js-about-bang-link" data-bang="w" data-query="filter bubble" href="https://duckduckgo.com/?q=!w+filter+bubble">!w filter bubble</a> will take you directly to Wikipedia.</p>
             <p class="bang--about__text">Remember, though, because your search is actually taking place on that other site, you are subject to that site’s policies, including its data collection practices.</p>
             <p class="bang--about__text">We’ve had bangs since 2008 as part of <a target="_blank" href="https://en.wikipedia.org/wiki/Shebang_(Unix)">our geek roots</a>. Now we have <a href="#bangs-list">more than 10,000 !bangs</a> and you can even <a href="/newbang">submit your own</a>.</p>
         </div>

--- a/share/site/duckduckgo/bang.tx
+++ b/share/site/duckduckgo/bang.tx
@@ -11,12 +11,10 @@
 <div class="bang bang--about blk blk--alt blk--arr">
     <div class="cw--c bang--about__cw">
         <div class="bang--about__content">
-            <h2 class="bang--about__title">What are bangs?</h2>
-            <p class="bang--about__snippet">Bangs allow you to search on thousands of sites, directly.</p>
-            <p class="bang--about__text">A search for <a class="js-about-bang-link" data-bang="amazon" data-query="shoes" href="#">!amazon shoes</a> will take you right to an Amazon search for shoes
-            on Amazon.com. Try <a class="js-about-bang-link" data-bang="a" data-query="shoes" href="#">!a shoes</a> or <a class="js-about-bang-link" data-bang="ebay" data-query="wallet" href="#">!ebay wallet</a>.
-            There are <a href="#bangs-list">thousands of !bangs</a> and you can even <a href="/newbang">submit your own</a>.</p>
-            <p class="bang--about__text">With our !bang autocomplete, it's even easier than ever to search directly on your favourite sites. <a href="#" class="js-about-bang-link" data-bang="a" data-query="clae shoes">Try it now!</a></p>
+            <h2 class="bang--about__snippet">What are bangs?</h2>
+            <p class="bang--about__text">Bangs are shortcuts that quickly take you to search results on other sites. For example, when you know you want to search on another site like Wikipedia or Amazon, our bangs get you there fastest. A search for <a class="js-about-bang-link" data-bang="w" data-query="filter bubble" href="#">!w filter bubble</a> will take you directly to Wikipedia.</p>
+            <p class="bang--about__text">Remember, though, because your search is actually taking place on that other site, you are subject to that site’s policies, including its data collection practices.</p>
+            <p class="bang--about__text">We’ve had bangs since 2008 as part of <a target="_blank" href="https://en.wikipedia.org/wiki/Shebang_(Unix)">our geek roots</a>. Now we have <a href="#bangs-list">more than 10,000 !bangs</a> and you can even <a href="/newbang">submit your own</a>.</p>
         </div>
     </div>
     <noscript>


### PR DESCRIPTION
## Description

Tweaks the phrasing on the bang page a bit. I also rejigged the classes slightly, see internal PR.

## Testing

- the updated copy should be there
- the interaction should still work (e.g. pressing on `!w filter bubble` should show the search bar with the bang prefilled)