### PR TITLE
Duckduckgo/Root.pm: Change anonymous tracking timeline date.

### DIFF
--- a/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
+++ b/lib/DDG/Publisher/Site/Duckduckgo/Root.pm
@@ -36,12 +36,12 @@ sub pages {{
 			type => 'news',
 			icon => 'launch-small',
 		},{
-			date => 'January 22, 2009',
+			date => 'March 15, 2010',
 			title => 'Anonymous',
 			snippet => 'We decided to make a bold move and not track your search history. Tracking is creepy.',
 			type => 'news',
 			icon => 'woman',
-			year => '2009',
+			year => '2010',
 		},{
 			date => 'January 11, 2011',
 			title => 'The Billboard',


### PR DESCRIPTION
Change it to a more accurate date on when we started to implement anonymity.

<img width="1607" alt="screen shot 2019-01-25 at 10 59 35 am" src="https://user-images.githubusercontent.com/81969/51852645-83cb1580-22f4-11e9-9779-42c50a7daadb.png">

