### PR TITLE
About page: replace team map with photo

### DIFF
--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -147,14 +147,12 @@
 
 <!-- Team Map -->
 <a class="anchor" name="team"></a>
-<div class="abt  abt--map  blk  blk--content  blk--alt  map  no-js__hide">
-	<div class="cw--c">
-		<a class="abt--map__link--right tx-up hide--screen-s js-static-link" href="/hiring">we're hiring</a>
+<div class="abt  abt--map  blk  blk--content  blk--alt">
+		<a class="btn btn--primary btn--rounded abt--map__link--right tx-up hide--screen-s js-static-link" href="/hiring">we're hiring</a>
 		<h2 class="abt__title">Our Global Team</h2>
-	</div>
-	<div class="js-team-map"></div>
+        <img class="abt--map__image" src="/hiring/images/duckduckgo_team.jpg">
 	<div class="cw--c hide show--screen-s">
-		<a class="abt--map__link tx-up js-static-link" href="/hiring">we're hiring</a>
+		<a class="btn btn--primary btn--rounded abt--map__link tx-up js-static-link" href="/hiring">we're hiring</a>
 	</div>
 </div>
 

--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -150,7 +150,9 @@
 <div class="abt  abt--map  blk  blk--content  blk--alt">
 		<a class="btn btn--primary btn--rounded abt--map__link--right tx-up hide--screen-s js-static-link" href="/hiring">we're hiring</a>
 		<h2 class="abt__title">Our Global Team</h2>
-        <img class="abt--map__image" src="/hiring/images/duckduckgo_team.jpg">
+        <div class="abt--map__team">
+            <img class="abt--map__team__image" src="/hiring/images/duckduckgo_team.jpg" alt="DuckDuckGo Team">
+        </div>
 	<div class="cw--c hide show--screen-s">
 		<a class="btn btn--primary btn--rounded abt--map__link tx-up js-static-link" href="/hiring">we're hiring</a>
 	</div>


### PR DESCRIPTION
## Description
Replaces the team map with a team photo.
Asana: https://app.asana.com/0/72649045549333/1109764254025247
cc @jagtalon @moollaza 

## Testing
You'll need to checkout the branch with core changes here: https://dub.duckduckgo.com/duckduckgo/ddg/pull/15043

1. Go to yourinstance.com/about
2. Scroll down to "Our Global Team"
3. Verify that the team map is not showing
4. Verify that the team photo is showing and is full-screen
5. Verify that "We're hiring" link is displayed as a blue button
6. Test various breakpoints and make sure that it looks OK