### PR TITLE
Replace About page team photo with map screenshot

### DIFF
--- a/share/site/duckduckgo/about.tx
+++ b/share/site/duckduckgo/about.tx
@@ -151,7 +151,7 @@
 		<a class="btn btn--primary btn--rounded abt--map__link--right tx-up hide--screen-s js-static-link" href="/hiring">we're hiring</a>
 		<h2 class="abt__title">Our Global Team</h2>
         <div class="abt--map__team">
-            <img class="abt--map__team__image" src="/hiring/images/duckduckgo_team.jpg" alt="DuckDuckGo Team">
+            <img class="abt--map__team__image" src="/hiring/images/duckduckgo_team.png" alt="DuckDuckGo Team Map">
         </div>
 	<div class="cw--c hide show--screen-s">
 		<a class="btn btn--primary btn--rounded abt--map__link tx-up js-static-link" href="/hiring">we're hiring</a>


### PR DESCRIPTION
## Description
Replaces About page team photo with a screenshot of the team map.

## Testing
1. Pull https://dub.duckduckgo.com/duckduckgo/ddg/pull/15081
2. Run `rex deploy:static_dev
3. Go to instance.duckduckgo.com/about and verify that the team map png is used in the html (it may not be immediately obvious since the css background image is displayed on the page, so you'll need to inspect the html to verify this).