### PR TITLE
Add email to press page for non-press inquiries.

### DIFF
--- a/share/site/duckduckgo/press.tx
+++ b/share/site/duckduckgo/press.tx
@@ -90,7 +90,7 @@
 				<h2 class="asset__card__title">Contact Us</h2>
 				<p class="asset__card__text">Reach out for press inquiries, including interview requests.</p>
 				<a href="mailto:press@duckduckgo.com" class="press__btn btn btn--primary tx-up js-static-link">press@duckduckgo.com</a>
-				<div class="tx--13 mg--small tx-clr--grey-dark">
+				<div class="tx--13 mg--small tx-clr--grey-dark press__alt-email">
 					For all non-press inquiries, please use <a href="mailto:open@duckduckgo.com">open@duckduckgo.com</a>
 				</div>
 			</div>

--- a/share/site/duckduckgo/press.tx
+++ b/share/site/duckduckgo/press.tx
@@ -88,8 +88,11 @@
 			<div class="asset__card">
 				<img src="/assets/icons/contact.svg" aria-hidden="true" class="asset__card__icon">
 				<h2 class="asset__card__title">Contact Us</h2>
-				<p class="asset__card__text">Reach out for further inquiries, interview requests, or just say hi.</p>
+				<p class="asset__card__text">Reach out for press inquiries, including interview requests.</p>
 				<a href="mailto:press@duckduckgo.com" class="press__btn btn btn--primary tx-up js-static-link">press@duckduckgo.com</a>
+				<div class="tx--13 mg--small tx-clr--grey-dark">
+					For all non-press inquiries, please use <a href="mailto:open@duckduckgo.com">open@duckduckgo.com</a>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Description
Add open@duckduckgo.com to the press page for non-press inquiries.

## Testing
Go to https://duckduckgo.com/press, the text above the press@duckduckgo.com button should be changed, and a new email open@duckduckgo.com should be added below.