### PR TITLE
Update help and feedback links

### DIFF
--- a/share/core/footer.tx
+++ b/share/core/footer.tx
@@ -7,7 +7,7 @@
 					<li><a href="https://duck.co/translate">Translate DuckDuckGo</a></li>
 					<li><a href="https://duck.co/forum/general">Join our Forums</a></li>
 					<li><a href="https://duck.co/blog">Browse our Blog</a></li>
-					<li><a href="https://duck.co/help/community-platform/xmpp">Chat via XMPP/Jabber</a></li>
+					<li><a href="https://help.duckduckgo.com/community-platform/xmpp">Chat via XMPP/Jabber</a></li>
 					<li><a href="https://github.com/duckduckgo/community-platform">Develop this site</a></li>
 					<li><a href="https://github.com/duckduckgo/duckduckgo/wiki">Develop instant answers</a></li>
 					<li><a href="https://duckduckgo.com/spread">Spread DuckDuckGo!</a></li>
@@ -23,7 +23,7 @@
 					<li><a href="https://duckduckgo.com/">Homepage</a></li>
 					<li><a href="https://donttrack.us/">DontTrack.us</a></li>
 					<li><a href="https://dontbubble.us/">DontBubble.us</a></li>
-					<li><a href="https://duck.co/help/">Help</a></li>
+					<li><a href="https://help.duckduckgo.com/">Help</a></li>
 					<li><a href="https://duck.co/">Forum</a></li>
 					<li><a href="http://cafepress.com/duckduckgo">Store</a></li>
 					<li><a href="http://www.stickermule.com/duckduckgo">Sticker Store</a></li>

--- a/share/core/footer_nav.tx
+++ b/share/core/footer_nav.tx
@@ -7,7 +7,7 @@
 				<li><a href="https://duckduckgo.com/bang">Bangs</a></li>
 				<li><a href="https://duckduckgo.com/spread">Spread</a></li>
 				<li><a href="https://duckduckgo.com/hiring">Careers</a></li>
-				<li><a href="https://duck.co/help">Help</a></li>
+				<li><a href="https://help.duckduckgo.com/">Help</a></li>
 			</ul>
 		</div>
 		<div class="blk--foot__nav-col  third  thirty--screen-s">

--- a/share/site/duckduckgo/api.tx
+++ b/share/site/duckduckgo/api.tx
@@ -32,7 +32,7 @@ and
 (<a href="https://api.duckduckgo.com/?q=!imdb+rushmore&format=json&pretty=1&no_redirect=1">API example</a>).
 
 <div style="margin-bottom:20px;"></div>
-This API does not include all of our links, however. That is, it is not a full search results API or a way to get DuckDuckGo results into your applications beyond our instant answers. Because of the way <a href="https://duck.co/help/results/sources">we generate our search results</a>, we unfortunately do not have the rights to fully syndicate our results, free or paid. For the same reason, we cannot allow framing our results without our branding. Please see <a href="https://duck.co/help/company/partnerships">our partnerships page</a> for more info on guidelines and getting in touch with us.
+This API does not include all of our links, however. That is, it is not a full search results API or a way to get DuckDuckGo results into your applications beyond our instant answers. Because of the way <a href="https://help.duckduckgo.com/results/sources">we generate our search results</a>, we unfortunately do not have the rights to fully syndicate our results, free or paid. For the same reason, we cannot allow framing our results without our branding. Please see <a href="https://help.duckduckgo.com/company/partnerships">our partnerships page</a> for more info on guidelines and getting in touch with us.
 
 <div style="margin-bottom:20px;"></div>
 Our long-term goal is for <a href="/tour">all of our instant answers</a> to be available through this open API. Many of these instant answers are open source via our <a href="https://duckduckhack.com/">DuckDuckHack</a> platform. Using that platform, you can add your own APIs and data sources as well.
@@ -58,8 +58,8 @@ To consume it yourself, you can use one of the language libraries listed below o
 Here are the requirements for use:
 <ul>
 <li>Attribution in each place you use our API for both us and any underlying source. For the source, you can link to the source's relevant detail page. For us, you can say <a href="/">Results from DuckDuckGo</a> with our logo (and link to the specific result page).
-<li>Non-commercial use unless you get <a href="https://duck.co/help/company/partnerships">email approval from us</a> (though we're generally fine with anything that isn't sketchy).
-<li>Use a descriptive <a href="https://duck.co/help/privacy/t">t parameter</a>, i.e. append &t=nameofapp to your requests.
+<li>Non-commercial use unless you get <a href="https://help.duckduckgo.com/company/partnerships/">email approval from us</a> (though we're generally fine with anything that isn't sketchy).
+<li>Use a descriptive <a href="https://help.duckduckgo.com/privacy/t/">t parameter</a>, i.e. append &t=nameofapp to your requests.
 </ul>
 
 Our overall goal is to get more people using DuckDuckGo, so please keep that in mind as well.
@@ -228,7 +228,7 @@ Not all of our instant answers are available right now via this API for a variet
 
 <p style="margin-top: 5px;">
 <span class="small">
-Yes and no. We do not want to confuse users into thinking that your application was made by us. Please see <a href="https://duck.co/help/company/partnerships">our partnerships page</a> for more info on guidelines and getting in touch with us.
+Yes and no. We do not want to confuse users into thinking that your application was made by us. Please see <a href="https://help.duckduckgo.com/company/partnerships/">our partnerships page</a> for more info on guidelines and getting in touch with us.
 </span>
 
 
@@ -237,7 +237,7 @@ Yes and no. We do not want to confuse users into thinking that your application 
 
 <p style="margin-top: 5px;">
 <span class="small">
-No, though many of the instant answers it provides are open source via our <a href="https://duckduckhack.com/">DuckDuckHack platform</a>, which is completely open source. For more information on DuckDuckGo open source, please see <a href="https://duck.co/help/open-source/opensource-overview">this help article</a>.
+No, though many of the instant answers it provides are open source via our <a href="https://duckduckhack.com/">DuckDuckHack platform</a>, which is completely open source. For more information on DuckDuckGo open source, please see <a href="https://help.duckduckgo.com/open-source/opensource-overview/">this help article</a>.
 </span>
 
 
@@ -246,9 +246,9 @@ No, though many of the instant answers it provides are open source via our <a hr
 
 <p style="margin-top: 5px;">
 <span class="small">
-We simply do not have the resources to support high queries per second (QPS) for a single machine. Generally, this isn't a problem because our API is designed to be used client-side by individual users after they take some specific action (like a search or right-click). We also get a lot of botnet attacks. As a result, there is automatic throttling for API requests that will probably not effect you if you use the API in a distributed fashion (i.e. on your application's front-end). For specific situations we also provide higher limits. If you feel you may be in such a situation, please <a href="https://duck.co/help/company/partnerships">reach out</a>. For legal limits, please see above for attribution and other requirements.
+We simply do not have the resources to support high queries per second (QPS) for a single machine. Generally, this isn't a problem because our API is designed to be used client-side by individual users after they take some specific action (like a search or right-click). We also get a lot of botnet attacks. As a result, there is automatic throttling for API requests that will probably not effect you if you use the API in a distributed fashion (i.e. on your application's front-end). For specific situations we also provide higher limits. If you feel you may be in such a situation, please <a href="https://help.duckduckgo.com/company/partnerships/">reach out</a>. For legal limits, please see above for attribution and other requirements.
 </span>
 
 
 <p style="margin-top: 25px;">
-If you have more questions, please <a href="https://duck.co/help/company/partnerships">let us know</a>.
+If you have more questions, please <a href="https://help.duckduckgo.com/company/partnerships/">let us know</a>.

--- a/share/site/duckduckgo/feedback.tx
+++ b/share/site/duckduckgo/feedback.tx
@@ -50,36 +50,12 @@
 
 	<div class="fb-step fb-step--active">
 		<i class="fb-step__icon ddgi-dax"></i>
-		<a href="https://duck.co/feedback/partner/" class="fb-step__body fb-step__body--btn"><: l("I'd like to learn about partnerships with DuckDuckGo.") :></a>
+		<a href="https://help.duckduckgo.com/company/partnerships/" class="fb-step__body fb-step__body--btn"><: l("I'd like to learn about partnerships with DuckDuckGo.") :></a>
 		<i class="fb-step__arrow ddgi-arrow-right"></i>
 	</div>
 
 	<div class="fb-step  fb-step--active">
-		<i class="fb-step__icon  ddgi-sad-search"></i>
-		<a href="https://duck.co/feedback/relevancy/" class="fb-step__body  fb-step__body--btn"><: l("I'd like to report bad relevancy.") :></a>
-		<i class="fb-step__arrow  ddgi-arrow-right"></i>
-	</div>
-
-	<div class="fb-step  fb-step--active">
 		<i class="fb-step__icon  ddgi-bang"></i>
-		<a href="https://duck.co/feedback/bang/" class="fb-step__body  fb-step__body--btn"><: l("I'd like to submit a new !bang.") :></a>
-		<i class="fb-step__arrow  ddgi-arrow-right"></i>
-	</div>
-
-	<div class="fb-step  fb-step--active">
-		<i class="fb-step__icon  ddgi-coffee"></i>
-		<a href="https://duck.co/feedback/feature/" class="fb-step__body  fb-step__body--btn"><: l("I've got a feature request.") :></a>
-		<i class="fb-step__arrow  ddgi-arrow-right"></i>
-	</div>
-
-	<div class="fb-step  fb-step--active">
-		<i class="fb-step__icon  ddgi-heart"></i>
-		<a href="https://duck.co/feedback/love/" class="fb-step__body  fb-step__body--btn"><: l("I want to tell you about something I love.") :></a>
-		<i class="fb-step__arrow  ddgi-arrow-right"></i>
-	</div>
-
-	<div class="fb-step  fb-step--active">
-		<i class="fb-step__icon  ddgi-trash"></i>
-		<a href="https://duck.co/feedback/nolove/" class="fb-step__body  fb-step__body--btn"><: l("I want to tell you about something I don't love.") :></a>
+		<a href="https://duckduckgo.com/newbang" class="fb-step__body  fb-step__body--btn"><: l("I'd like to submit a new !bang.") :></a>
 		<i class="fb-step__arrow  ddgi-arrow-right"></i>
 	</div>

--- a/share/site/duckduckgo/feedback.tx
+++ b/share/site/duckduckgo/feedback.tx
@@ -1,6 +1,6 @@
   <div id="dest-boxes">
     <div class="feedback-dest">
-			<a href="https://duck.co/help">
+			<a href="https://help.duckduckgo.com/">
 				<img src="/assets/logos/logo_feedback.help.png" class="feedback-dest__img" alt="Dax the Helpful Doctor" />
 				<div class="feedback-dest__body">
 					<h2 class="feedback-dest__title"><: l('Help') :></h2>

--- a/share/site/duckduckgo/params.tx
+++ b/share/site/duckduckgo/params.tx
@@ -24,7 +24,7 @@
 &nbsp; &nbsp; <span class="clu">https://duckduckgo.com/?q=search&amp;kp=-1&amp;kl=us-en</span>
 
 <div style="padding-top:25px;"></div>
-These parameters are intended for individual use. They can also be used in conjunction with our <a href="/search_box">site search</a> to customize results pages more closely to your site. However, if using them for that purpose or any other beyond individual use (e.g. for apps/extensions), please do not remove our branding (ko, kr  params etc.) or advertising (k1, k4 params etc.) as we have contracts in place that we would be violating if you did so. Please see <a href="https://duck.co/help/company/partnerships">our partnerships page</a> for more info on guidelines and getting in touch with us.
+These parameters are intended for individual use. They can also be used in conjunction with our <a href="/search_box">site search</a> to customize results pages more closely to your site. However, if using them for that purpose or any other beyond individual use (e.g. for apps/extensions), please do not remove our branding (ko, kr  params etc.) or advertising (k1, k4 params etc.) as we have contracts in place that we would be violating if you did so. Please see <a href="https://help.duckduckgo.com/company/partnerships/">our partnerships page</a> for more info on guidelines and getting in touch with us.
 
 <div style="margin-bottom:30px;"></div>
 <table>
@@ -534,7 +534,7 @@ kaj =
 t =
 <ul>
 <li><: l('A string to identify the source.') :>
-<li><: lp('moreinfo','See %s for more info.',r('<a href="https://duck.co/help/privacy/t">') ~ lp('moreinfo','this help page') ~ r('</a>')) :>
+<li><: lp('moreinfo','See %s for more info.',r('<a href="https://help.duckduckgo.com/privacy/t/">') ~ lp('moreinfo','this help page') ~ r('</a>')) :>
 </td>
 </tr>
 

--- a/share/site/duckduckgo/privacy.tx
+++ b/share/site/duckduckgo/privacy.tx
@@ -52,7 +52,7 @@
 
 <p>Another way to prevent search leakage is by using something called a <a href="/?q=POST+request">POST request</a>, which has the effect of not showing your search in your browser, and, as a consequence, does not send it to other sites. You can turn on POST requests on our <a href="/settings">settings page</a>, but it has its own issues. POST requests usually break browser back buttons, and they make it impossible for you to easily share your search by copying and pasting it out of your Web browser's address bar.</p>
 
-<p>Finally, if you want to prevent sites from knowing you visited them at all, you can use a proxy like <a href="https://www.torproject.org/">Tor</a>. DuckDuckGo actually operates a <a href="https://duck.co/help/privacy/tor-exit-enclave">Tor exit enclave</a>, which means you can get end to end anonymous and encrypted searching using Tor & DDG together.</p>
+<p>Finally, if you want to prevent sites from knowing you visited them at all, you can use a proxy like <a href="https://www.torproject.org/">Tor</a>. DuckDuckGo actually operates a <a href="https://help.duckduckgo.com/privacy/tor-exit-enclave/">Tor exit enclave</a>, which means you can get end to end anonymous and encrypted searching using Tor & DDG together.</p>
 
 <p>You can enter !proxy domain into DuckDuckGo as well, and we will route you through a proxy, e.g. <a href="/?q=!proxy+breadpig.com">!proxy breadpig.com</a>. This feature is part of our <a href="/bang">!bang syntax</a>. Unfortunately, proxies can also be slow, and free proxies (like the one we use) are funded by arguably excessive advertising.</p>
 

--- a/share/site/duckduckgo/search_box.tx
+++ b/share/site/duckduckgo/search_box.tx
@@ -22,7 +22,7 @@ pre {
 <: l('Feel free to adjust the settings below. Then, just copy and paste the code into your website.') :>
 
 <div style="margin-bottom:15px;"></div>
-Because of the way <a href="https://duck.co/help/results/sources">we generate our search results</a>, we do not have the syndication rights to allow you to host our results on your site (e.g. in a frame). When your users click on the results they will be instead taken to our site. Please see <a href="https://duck.co/help/company/partnerships">our partnerships page</a> for more info on guidelines and getting in touch with us.
+Because of the way <a href="https://help.duckduckgo.com/results/sources/">we generate our search results</a>, we do not have the syndication rights to allow you to host our results on your site (e.g. in a frame). When your users click on the results they will be instead taken to our site. Please see <a href="https://help.duckduckgo.com/company/partnerships/">our partnerships page</a> for more info on guidelines and getting in touch with us.
 
 <div style="margin-bottom:30px;"></div>
 <iframe id="code_frame" src="/search.html" style="overflow:hidden;margin:0;padding:0;width:550px;height:39px;" frameborder="0"></iframe>


### PR DESCRIPTION
## Description

- Updating old help links
- Removing duck.co links from feedback, linking directly to pages where feasible

## Testing
