### PR TITLE
Changed community url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Installation
 
-You require the following libraries of https://duckpan.org/
+You require the following libraries of https://duck.co/
 
  - DDG
  - DDGC::Locale::DuckduckgoDuckduckgo


### PR DESCRIPTION
certificate for duckpan.org is invalid and it's forwarding to duck.co anyways.
